### PR TITLE
Feat/daily usage

### DIFF
--- a/app/models/daily_usage.rb
+++ b/app/models/daily_usage.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class DailyUsage
-  include ActiveModel::Model
-
-  attr_accessor :kilowatts,
-                :appliance_quantity,
-                :cycle_quantity
-end

--- a/app/models/daily_usage_creation/wizard.rb
+++ b/app/models/daily_usage_creation/wizard.rb
@@ -12,7 +12,44 @@ module DailyUsageCreation
     private
 
     def do_complete
+      # this is all temporary
+      usage = if @store[:cyclical?]
+                create_cyclical_daily_usage(@store)
+              else
+                create_time_based_daily_usage(@store)
+              end
+
       Rails.logger.debug "Form complete"
+      Rails.logger.info @store.inspect
+      Rails.logger.debug usage.to_json
+    end
+
+    def create_cyclical_daily_usage(store)
+      raise NotImplementedError
+    end
+
+    def create_time_based_daily_usage(store)
+      TimeBasedDailyUsage.new(
+        appliance: {
+          name: store["added_appliance"]["data"]["name"],
+          wattage: store["added_appliance"]["data"]["wattage"],
+          quantity: store["quantity"]
+        },
+        hours_used: per_day(store["hours"], store["frequency"]),
+        minutes_used: per_day(store["minutes"], store["frequency"]),
+        additional_usage: store["added_appliance"]["data"]["additionalUsage"]
+      )
+    end
+
+    def per_day(time, frequency)
+      return if time.blank?
+
+      case frequency
+      when "daily"
+        time
+      when "weekly"
+        time / 7.to_f
+      end
     end
   end
 end

--- a/app/models/time_based_daily_usage.rb
+++ b/app/models/time_based_daily_usage.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class TimeBasedDailyUsage
+  include ActiveModel::Model
+
+  attr_writer :appliance_name,
+              :wattage,
+              :appliance_quantity,
+              :minutes_used,
+              :additional_usage
+
+end

--- a/app/models/time_based_daily_usage.rb
+++ b/app/models/time_based_daily_usage.rb
@@ -1,12 +1,48 @@
 # frozen_string_literal: true
 
+require "bigdecimal"
+
+# Represents a single day's usage of a given appliance and calculates the kWh consumed for a given timespan
 class TimeBasedDailyUsage
   include ActiveModel::Model
 
-  attr_writer :appliance_name,
-              :wattage,
-              :appliance_quantity,
-              :minutes_used,
-              :additional_usage
+  class UnrecognisedTimespanError < StandardError; end
 
+  attr_reader :appliance_name
+
+  def initialize(appliance:, hours_used:, minutes_used:, additional_usage:)
+    @appliance_name = appliance[:name]
+    @appliance_quantity = appliance[:quantity]
+    @wattage = appliance[:wattage].to_f
+    @hours_used = hours_used.to_f || 0.0
+    @minutes_used = minutes_used.to_f || 0.0
+    @additional_usage = additional_usage.to_f || 0.0
+  end
+
+  def kwh_per(timespan)
+    case timespan
+    when :day
+      kilowatts * hours_used_per_day
+    when :week
+      kilowatts * hours_used_per_day * 7
+    when :month
+      kilowatts * hours_used_per_day * days_in_a_month
+    else
+      raise UnrecognisedTimespanError.new(msg: "Unrecognised timespan #{timespan} given to TimeBasedDailyUsage")
+    end
+  end
+
+  private
+
+  def hours_used_per_day
+    @hours_used + ((@minutes_used + @additional_usage) / 60)
+  end
+
+  def kilowatts
+    @appliance_quantity * @wattage / 1000
+  end
+
+  def days_in_a_month
+    365.0 / 12.0
+  end
 end

--- a/spec/factories/time_base_daily_usage.rb
+++ b/spec/factories/time_base_daily_usage.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :time_based_daily_usage, class: "TimeBasedDailyUsage" do
+    appliance_name { "A test appliance (time based)" }
+    appliance_quantity { 1 }
+    wattage { 10_000 }
+    hours_used { 1 }
+    minutes_used { 30 }
+    additional_usage { nil }
+
+    trait :with_additional_usage do
+      additional_usage { 10 }
+    end
+
+    trait :with_fractional_time do
+      hours_used { 1.4286 } # 10 hours per week
+    end
+
+    trait :with_multiple_appliances do
+      appliance_quantity { 2 }
+    end
+
+    initialize_with { new(appliance: { name: appliance_name, quantity: appliance_quantity, wattage: }, hours_used:, minutes_used:, additional_usage:) }
+  end
+end

--- a/spec/factories/time_base_daily_usage.rb
+++ b/spec/factories/time_base_daily_usage.rb
@@ -21,6 +21,8 @@ FactoryBot.define do
       appliance_quantity { 2 }
     end
 
-    initialize_with { new(appliance: { name: appliance_name, quantity: appliance_quantity, wattage: }, hours_used:, minutes_used:, additional_usage:) }
+    initialize_with do
+      new(appliance: { name: appliance_name, quantity: appliance_quantity, wattage: }, hours_used:, minutes_used:, additional_usage:)
+    end
   end
 end

--- a/spec/models/time_based_daily_usage_spec.rb
+++ b/spec/models/time_based_daily_usage_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe(TimeBasedDailyUsage) do
+  # kWh = wattage / 1000 * usage in hours
+  describe "#kwh_per" do
+    context "when a single appliance" do
+      subject { build(:time_based_daily_usage).kwh_per(timespan) }
+
+      context "when per day" do
+        let(:timespan) { :day }
+
+        # (10000 watts / 1000 ) * (90 minutes / 60) = 15kWh
+        it { is_expected.to eq 15 }
+      end
+
+      context "when per week" do
+        let(:timespan) { :week }
+
+        # (10000 watts / 1000 ) * (90 minutes / 60) * 7 = 105kWh
+        it { is_expected.to eq 105 }
+      end
+
+      context "when per month" do
+        let(:timespan) { :month }
+
+        # (10000 watts / 1000 ) * (90 minutes / 60) * 365 / 12 = 456.25kWh
+        it { is_expected.to eq 456.25 }
+      end
+    end
+
+    context "when multiple appliances" do
+      subject { build(:time_based_daily_usage, :with_multiple_appliances).kwh_per(timespan) }
+
+      context "when per day" do
+        let(:timespan) { :day }
+
+        # (10000 watts / 1000 ) * (90 minutes / 60) * 2 = 30kWh
+        it { is_expected.to eq 30 }
+      end
+
+      context "when per week" do
+        let(:timespan) { :week }
+
+        # (10000 watts / 1000 ) * (90 minutes / 60) * 7 * 2 = 210kWh
+        it { is_expected.to eq 210 }
+      end
+
+      context "when per month" do
+        let(:timespan) { :month }
+
+        # (10000 watts / 1000 ) * (90 minutes / 60) * 365 / 12 * 2 = 912.5kWh
+        it { is_expected.to eq 912.5 }
+      end
+    end
+
+    context "with fractional time used" do
+      subject { build(:time_based_daily_usage, :with_fractional_time).kwh_per(timespan) }
+
+      context "when per day" do
+        let(:timespan) { :day }
+
+        # (10000 watts / 1000 ) * (1.4268 hours + (30 minutes / 60)) = 19.286kWh
+        it { is_expected.to eq 19.286 }
+      end
+
+      context "when per week" do
+        let(:timespan) { :week }
+
+        # (10000 watts / 1000 ) * (1.4268 hours + (30 minutes / 60)) * 7  = 135.002kWh
+        it { is_expected.to eq 135.002 }
+      end
+
+      context "when per month" do
+        let(:timespan) { :month }
+
+        # (10000 watts / 1000 ) * (1.4268 hours + (30 minutes / 60)) * 365 / 12 * 2 = 586.068333334kWh
+        it { is_expected.to eq 586.6158333333334 }
+      end
+    end
+
+    context "with additional usage" do
+      subject { build(:time_based_daily_usage, :with_additional_usage).kwh_per(timespan) }
+
+      context "when per day" do
+        let(:timespan) { :day }
+
+        # (10000 watts / 1000 ) * ((90 + 10) minutes / 60) = 16.66666667kWh
+        it { is_expected.to eq 16.666666666666664 }
+      end
+
+      context "when per week" do
+        let(:timespan) { :week }
+
+        # (10000 watts / 1000 ) * ((90 + 10) minutes / 60) * 7  = 116.66666666666666kWh
+        it { is_expected.to eq 116.66666666666666 }
+      end
+
+      context "when per month" do
+        let(:timespan) { :month }
+
+        # (10000 watts / 1000 ) * ((90 + 10) minutes / 60) * 365 / 12 * 2 = 506.9444444444444kWh
+        it { is_expected.to eq 506.9444444444444 }
+      end
+    end
+
+    context "when an unknown timespan is provided" do
+      subject(:usage) { build(:time_based_daily_usage) }
+
+      it "raises an error" do
+        expect { usage.kwh_per(:banana) }.to raise_error(TimeBasedDailyUsage::UnrecognisedTimespanError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a `TimeBasedDailyUsage` object that is created at the end of the form.  It represents the daily usage of a non-cyclical appliance, like a light bulb.

Some things to note:
- it's not clear what the formulaic requirements are for rounding kWh yet.  The figure will be multiplied by the `unit_rate` to give a total cost, which will then be rounded and presented to a user.  So, for now, I haven't added any rounding to the kWh numbers generated by `#kwh_for`
- not totally sure what the final `#do_complete` for the wizard will look like - this is just placeholder atm