### PR TITLE
Feat/cyclical daily usage

### DIFF
--- a/app/controllers/appliance_calculator/daily_usage_creation/steps_controller.rb
+++ b/app/controllers/appliance_calculator/daily_usage_creation/steps_controller.rb
@@ -24,6 +24,10 @@ module ApplianceCalculator
       def wizard_store_key
         :daily_usage_creation
       end
+
+      def on_complete(usage)
+        Rails.logger.info usage.inspect
+      end
     end
   end
 end

--- a/app/models/cyclical_daily_usage.rb
+++ b/app/models/cyclical_daily_usage.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Represents a single day's usage of a given appliance and calculates the kWh consumed for a given timespan
+class CyclicalDailyUsage
+  include ActiveModel::Model
+
+  class UnrecognisedTimespanError < StandardError; end
+
+  attr_reader :label, :details
+
+  def initialize(label:, details:, wattage:, cycle_quantity:)
+    @label = label
+    @details = details
+    @wattage = wattage.to_f
+    @cycle_quantity = cycle_quantity.to_f
+  end
+
+  def kwh_per(timespan)
+    case timespan
+    when :day
+      kilowatts * @cycle_quantity
+    when :week
+      kilowatts * @cycle_quantity * 7
+    when :month
+      kilowatts * @cycle_quantity * days_in_a_month
+    else
+      raise UnrecognisedTimespanError.new(msg: "Unrecognised timespan #{timespan} given to CyclicalDailyUsage")
+    end
+  end
+
+  private
+
+  def kilowatts
+    @wattage / 1000
+  end
+
+  def days_in_a_month
+    365.0 / 12.0
+  end
+end

--- a/app/models/daily_usage_creation/builders/usage_builder.rb
+++ b/app/models/daily_usage_creation/builders/usage_builder.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module DailyUsageCreation
+  module Builders
+    class UsageBuilder
+      def initialize(store)
+        @appliance = ::Appliance.new(data: store[:added_appliance]["data"])
+        @store = store
+      end
+
+      def build
+        raise NotImplementedError unless cyclical?
+
+        build_cyclical_usage
+      end
+
+      private
+
+      def cyclical?
+        @store["cyclical?"]
+      end
+
+      def build_cyclical_usage
+        CyclicalDailyUsage.new(
+          label: label,
+          details: cyclical_details,
+          wattage: @store["wattage"],
+          cycle_quantity: cycle_quantity
+        )
+      end
+
+      def label
+        return @appliance.data["name"] unless cyclical?
+
+        [@appliance.data["name"], selected_variant_text, cycle_text].compact.join(", ")
+      end
+
+      def selected_variant_text
+        return if @appliance.variant_options.blank?
+
+        variant = @appliance.variant_options.find { |option| option.value == @store["wattage"] }
+        variant.text
+      end
+
+      def cycle_text
+        frequency = case @store["frequency"]
+                    when "daily"
+                      "day"
+                    else
+                      "week"
+                    end
+
+        "#{@store['cycles']} cycles per #{frequency}"
+      end
+
+      def cyclical_details
+        [
+          "Cycle(s): #{@store['cycles']}",
+          selected_variant_text
+        ].compact
+      end
+
+      def cycle_quantity
+        case @store["frequency"]
+        when "daily"
+          @store["cycles"]
+        else
+          @store["cycles"].to_f / 7
+        end
+      end
+    end
+  end
+end

--- a/app/models/daily_usage_creation/wizard.rb
+++ b/app/models/daily_usage_creation/wizard.rb
@@ -12,44 +12,8 @@ module DailyUsageCreation
     private
 
     def do_complete
-      # this is all temporary
-      usage = if @store[:cyclical?]
-                create_cyclical_daily_usage(@store)
-              else
-                create_time_based_daily_usage(@store)
-              end
-
-      Rails.logger.debug "Form complete"
       Rails.logger.info @store.inspect
-      Rails.logger.debug usage.to_json
-    end
-
-    def create_cyclical_daily_usage(store)
-      raise NotImplementedError
-    end
-
-    def create_time_based_daily_usage(store)
-      TimeBasedDailyUsage.new(
-        appliance: {
-          name: store["added_appliance"]["data"]["name"],
-          wattage: store["added_appliance"]["data"]["wattage"],
-          quantity: store["quantity"]
-        },
-        hours_used: per_day(store["hours"], store["frequency"]),
-        minutes_used: per_day(store["minutes"], store["frequency"]),
-        additional_usage: store["added_appliance"]["data"]["additionalUsage"]
-      )
-    end
-
-    def per_day(time, frequency)
-      return if time.blank?
-
-      case frequency
-      when "daily"
-        time
-      when "weekly"
-        time / 7.to_f
-      end
+      Builders::UsageBuilder.new(@store).build
     end
   end
 end

--- a/spec/factories/cyclical_daily_usage.rb
+++ b/spec/factories/cyclical_daily_usage.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :cyclical_daily_usage, class: "CyclicalDailyUsage" do
+    label { "My appliance" }
+    details { ["Cycle(s): 2", "Full load"] }
+    wattage { 10_000 }
+    cycle_quantity { 2 }
+
+    initialize_with do
+      new(label:, details:, wattage:, cycle_quantity:)
+    end
+  end
+end

--- a/spec/models/cyclical_daily_usage_spec.rb
+++ b/spec/models/cyclical_daily_usage_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe(CyclicalDailyUsage) do
+  # kWh = wattage per cycle / 1000 * number of cycles
+  describe "#kwh_per" do
+    subject { build(:cyclical_daily_usage).kwh_per(timespan) }
+
+    context "when per day" do
+      let(:timespan) { :day }
+
+      # (10000 watts / 1000 ) * 2 = 20kWh
+      it { is_expected.to eq 20 }
+    end
+
+    context "when per week" do
+      let(:timespan) { :week }
+
+      # (10000 watts / 1000 ) * 2 * 7 = 140kWh
+      it { is_expected.to eq 140 }
+    end
+
+    context "when per month" do
+      let(:timespan) { :month }
+
+      # (10000 watts / 1000 ) * 2 * 365 / 12 = 608.3333333333334kWh
+      it { is_expected.to eq 608.3333333333334 }
+    end
+  end
+end

--- a/spec/models/daily_usage_creation/builders/usage_builder_spec.rb
+++ b/spec/models/daily_usage_creation/builders/usage_builder_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe(DailyUsageCreation::Builders::UsageBuilder) do
+  describe "#build" do
+    subject { described_class.new(store).build }
+
+    let(:store) do
+      WizardSteps::Store.new(
+        {
+          "cyclical?" => cyclical,
+          "added_appliance" => added_appliance,
+          "cycles" => "10",
+          "frequency" => "weekly",
+          "wattage" => "1000"
+        }
+      )
+    end
+
+    let(:added_appliance) do
+      {
+        "data" => {
+          "sys" => {
+            "id" => "7mmSMkn7tbxU9l5IXLr6GF"
+          },
+          "name" => "TEST - Tumble Dryer (condenser)",
+          "category" => "Large appliances",
+          "wattage" => 0,
+          "usageType" => "Cycles",
+          "variantOptions" => variant_options
+        }
+      }
+    end
+
+    context "when the appliance is cyclical" do
+      let(:cyclical) { true }
+
+      context "when the appliance has no variants" do
+        let(:variant_options) { nil }
+
+        it { is_expected.to be_a CyclicalDailyUsage }
+        its(:label) { is_expected.to eq "TEST - Tumble Dryer (condenser), 10 cycles per week" }
+        its(:details) { is_expected.to eq ["Cycle(s): 10"] }
+      end
+
+      context "when the appliance has variants" do
+        let(:variant_options) { { "tableData" => [["Option", "Wattage"], ["Full load", "1000"], ["Partial load", "200"]] } }
+
+        its(:label) { is_expected.to eq "TEST - Tumble Dryer (condenser), Full load, 10 cycles per week" }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates the `CyclicalDailyUsage` object that represents the daily usage of a cyclical appliance, like a tumble dryer.

Also creates a `UsageBuilder` which moves the responsibility of creating the usage objects from the wizard to its own class.

I will update the the builder to build time based usages in a different PR.