### PR TITLE
Feat/time based daily usage

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,6 @@ Rails/I18nLocaleTexts:
     # We aren't translating the error messages into another language
     # so it's simpler to have the error msgs next to the validation rules
     - "app/models/daily_usage_creation/steps/*.rb"
+
+RSpec/ExampleLength:
+ CountAsOne: ['hash', 'array']

--- a/app/models/time_based_daily_usage.rb
+++ b/app/models/time_based_daily_usage.rb
@@ -8,25 +8,23 @@ class TimeBasedDailyUsage
 
   class UnrecognisedTimespanError < StandardError; end
 
-  attr_reader :appliance_name
+  attr_reader :label, :details
 
-  def initialize(appliance:, hours_used:, minutes_used:, additional_usage:)
-    @appliance_name = appliance[:name]
-    @appliance_quantity = appliance[:quantity]
-    @wattage = appliance[:wattage].to_f
-    @hours_used = hours_used.to_f || 0.0
-    @minutes_used = minutes_used.to_f || 0.0
-    @additional_usage = additional_usage.to_f || 0.0
+  def initialize(label:, details:, wattage:, hours_used:)
+    @label = label
+    @details = details
+    @wattage = wattage.to_f
+    @hours_used = hours_used.to_f
   end
 
   def kwh_per(timespan)
     case timespan
     when :day
-      kilowatts * hours_used_per_day
+      kilowatts * @hours_used
     when :week
-      kilowatts * hours_used_per_day * 7
+      kilowatts * @hours_used * 7
     when :month
-      kilowatts * hours_used_per_day * days_in_a_month
+      kilowatts * @hours_used * days_in_a_month
     else
       raise UnrecognisedTimespanError.new(msg: "Unrecognised timespan #{timespan} given to TimeBasedDailyUsage")
     end
@@ -34,12 +32,8 @@ class TimeBasedDailyUsage
 
   private
 
-  def hours_used_per_day
-    @hours_used + ((@minutes_used + @additional_usage) / 60)
-  end
-
   def kilowatts
-    @appliance_quantity * @wattage / 1000
+    @wattage / 1000
   end
 
   def days_in_a_month

--- a/spec/factories/time_base_daily_usage.rb
+++ b/spec/factories/time_base_daily_usage.rb
@@ -2,27 +2,17 @@
 
 FactoryBot.define do
   factory :time_based_daily_usage, class: "TimeBasedDailyUsage" do
-    appliance_name { "A test appliance (time based)" }
-    appliance_quantity { 1 }
+    label { "A test appliance (time based)" }
+    details { ["Quantity: 1", "Duration: 1 hr 30 minutes"] }
     wattage { 10_000 }
-    hours_used { 1 }
-    minutes_used { 30 }
-    additional_usage { nil }
+    hours_used { 1.5 }
 
     trait :with_additional_usage do
-      additional_usage { 10 }
-    end
-
-    trait :with_fractional_time do
-      hours_used { 1.4286 } # 10 hours per week
-    end
-
-    trait :with_multiple_appliances do
-      appliance_quantity { 2 }
+      hours_used { 1.5 + (10.0 / 60.0) }
     end
 
     initialize_with do
-      new(appliance: { name: appliance_name, quantity: appliance_quantity, wattage: }, hours_used:, minutes_used:, additional_usage:)
+      new(label:, details:, wattage:, hours_used:)
     end
   end
 end

--- a/spec/models/daily_usage_creation/builders/usage_builder_spec.rb
+++ b/spec/models/daily_usage_creation/builders/usage_builder_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe(DailyUsageCreation::Builders::UsageBuilder) do
   describe "#build" do
-    subject { described_class.new(store).build }
+    subject(:builder) { described_class.new(store) }
 
     let(:store) do
       WizardSteps::Store.new(
@@ -13,7 +13,7 @@ RSpec.describe(DailyUsageCreation::Builders::UsageBuilder) do
           "added_appliance" => added_appliance,
           "cycles" => "10",
           "frequency" => "weekly",
-          "wattage" => "1000"
+          "wattage" => "200"
         }
       )
     end
@@ -26,28 +26,52 @@ RSpec.describe(DailyUsageCreation::Builders::UsageBuilder) do
           },
           "name" => "TEST - Tumble Dryer (condenser)",
           "category" => "Large appliances",
-          "wattage" => 0,
+          "wattage" => "1000",
           "usageType" => "Cycles",
-          "variantOptions" => variant_options
+          "variantOptions" => variant_options.presence
         }
       }
     end
 
     context "when the appliance is cyclical" do
       let(:cyclical) { true }
+      let(:variant_options) { nil }
+
+      let(:cyclical_usage_double) { instance_double(CyclicalDailyUsage) }
+
+      before do
+        allow(CyclicalDailyUsage).to receive(:new).and_return(cyclical_usage_double)
+        builder.build
+      end
+
+      it "creates the correct type of usage" do
+        expect(CyclicalDailyUsage).to have_received(:new)
+      end
 
       context "when the appliance has no variants" do
-        let(:variant_options) { nil }
-
-        it { is_expected.to be_a CyclicalDailyUsage }
-        its(:label) { is_expected.to eq "TEST - Tumble Dryer (condenser), 10 cycles per week" }
-        its(:details) { is_expected.to eq ["Cycle(s): 10"] }
+        it "passes the correct label, details, wattage and cycle quantity" do
+          expected_params = {
+            label: "TEST - Tumble Dryer (condenser), 10 cycles per week",
+            details: ["Cycle(s): 10"],
+            wattage: "1000", # wattage is taken from the appliance not the chosen input
+            cycle_quantity: 1.4285714285714286 # 10 cycles per week / 7
+          }
+          expect(CyclicalDailyUsage).to have_received(:new).with(expected_params)
+        end
       end
 
       context "when the appliance has variants" do
         let(:variant_options) { { "tableData" => [["Option", "Wattage"], ["Full load", "1000"], ["Partial load", "200"]] } }
 
-        its(:label) { is_expected.to eq "TEST - Tumble Dryer (condenser), Full load, 10 cycles per week" }
+        it "passes the correct label, details, wattage and cycle quantity" do
+          expected_params = {
+            label: "TEST - Tumble Dryer (condenser), Partial load, 10 cycles per week",
+            details: ["Cycle(s): 10", "Partial load"],
+            wattage: "200", # wattage is taken from chosen input
+            cycle_quantity: 1.4285714285714286 # 10 cycles per week / 7
+          }
+          expect(CyclicalDailyUsage).to have_received(:new).with(expected_params)
+        end
       end
     end
   end

--- a/spec/models/time_based_daily_usage_spec.rb
+++ b/spec/models/time_based_daily_usage_spec.rb
@@ -30,56 +30,6 @@ RSpec.describe(TimeBasedDailyUsage) do
       end
     end
 
-    context "when multiple appliances" do
-      subject { build(:time_based_daily_usage, :with_multiple_appliances).kwh_per(timespan) }
-
-      context "when per day" do
-        let(:timespan) { :day }
-
-        # (10000 watts / 1000 ) * (90 minutes / 60) * 2 = 30kWh
-        it { is_expected.to eq 30 }
-      end
-
-      context "when per week" do
-        let(:timespan) { :week }
-
-        # (10000 watts / 1000 ) * (90 minutes / 60) * 7 * 2 = 210kWh
-        it { is_expected.to eq 210 }
-      end
-
-      context "when per month" do
-        let(:timespan) { :month }
-
-        # (10000 watts / 1000 ) * (90 minutes / 60) * 365 / 12 * 2 = 912.5kWh
-        it { is_expected.to eq 912.5 }
-      end
-    end
-
-    context "with fractional time used" do
-      subject { build(:time_based_daily_usage, :with_fractional_time).kwh_per(timespan) }
-
-      context "when per day" do
-        let(:timespan) { :day }
-
-        # (10000 watts / 1000 ) * (1.4268 hours + (30 minutes / 60)) = 19.286kWh
-        it { is_expected.to eq 19.286 }
-      end
-
-      context "when per week" do
-        let(:timespan) { :week }
-
-        # (10000 watts / 1000 ) * (1.4268 hours + (30 minutes / 60)) * 7  = 135.002kWh
-        it { is_expected.to eq 135.002 }
-      end
-
-      context "when per month" do
-        let(:timespan) { :month }
-
-        # (10000 watts / 1000 ) * (1.4268 hours + (30 minutes / 60)) * 365 / 12 * 2 = 586.068333334kWh
-        it { is_expected.to eq 586.6158333333334 }
-      end
-    end
-
     context "with additional usage" do
       subject { build(:time_based_daily_usage, :with_additional_usage).kwh_per(timespan) }
 
@@ -87,21 +37,21 @@ RSpec.describe(TimeBasedDailyUsage) do
         let(:timespan) { :day }
 
         # (10000 watts / 1000 ) * ((90 + 10) minutes / 60) = 16.66666667kWh
-        it { is_expected.to eq 16.666666666666664 }
+        it { is_expected.to eq 16.666666666666668 }
       end
 
       context "when per week" do
         let(:timespan) { :week }
 
         # (10000 watts / 1000 ) * ((90 + 10) minutes / 60) * 7  = 116.66666666666666kWh
-        it { is_expected.to eq 116.66666666666666 }
+        it { is_expected.to eq 116.66666666666667 }
       end
 
       context "when per month" do
         let(:timespan) { :month }
 
         # (10000 watts / 1000 ) * ((90 + 10) minutes / 60) * 365 / 12 * 2 = 506.9444444444444kWh
-        it { is_expected.to eq 506.9444444444444 }
+        it { is_expected.to eq 506.9444444444445 }
       end
     end
 


### PR DESCRIPTION
Adds the `TimeBasedDailyUsage` to the `UsageBuilder`.  This led to a refactor of the `TimeBasedDailyUsage` to simplify it and bring it in line with the `CyclicalDailyUsage`.  

This means that both types now have the same interface although I don't think it's worth making them the same object (or subclasses of something more generic), and I think having them separate makes it easier to understand what's happening.

The refactor means that a lot of the testing previously done in the usage spec is now done in the builder spec, as that is now responsible for working out the total number of hours used.