### PR TITLE
Feat/datadog js monitoring

### DIFF
--- a/.github/workflows/deploy-energy-apps.yaml
+++ b/.github/workflows/deploy-energy-apps.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        stage: ["dev", "prod"]
+        stage: ["dev"]
     environment:
       name: ${{ matrix.stage }}
     steps:

--- a/.github/workflows/upload-js-to-datadog.yml
+++ b/.github/workflows/upload-js-to-datadog.yml
@@ -1,0 +1,42 @@
+name: Upload JS and sourcemaps to DataDog
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Deploy Energy Apps"]
+    types:
+      - completed
+
+jobs:
+  dd-js-upload:
+    env:
+      DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+      DATADOG_SITE: datadoghq.eu
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Setup ruby"
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: "Setup node"
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: "Install npm packages"
+        uses: bahmutov/npm-install@v1
+
+      - name: "Install datadog-ci upload tools"
+        run: npm install -g @datadog/datadog-ci
+
+      - name: "Precompile assets"
+        run: bundle exec rails assets:precompile
+
+      - name: "Upload js assets"
+        run: | 
+          datadog-ci sourcemaps upload ./public/energy-apps-assets \
+          --service=energy-apps \
+          --release-version=${{ github.sha }} \
+          --minified-path-prefix=/energy-apps-assets/

--- a/.github/workflows/upload-js-to-datadog.yml
+++ b/.github/workflows/upload-js-to-datadog.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   dd-js-upload:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       DATADOG_SITE: datadoghq.eu
-    steps:
+    steps:g
       - name: "Checkout"
         uses: actions/checkout@v4
 

--- a/app/javascript/appliance-calculator.js
+++ b/app/javascript/appliance-calculator.js
@@ -1,7 +1,11 @@
 import initErrorSummary from '@citizensadvice/design-system/lib/error-summary';
 import initDismissNotice from "./modules/last_added_appliance";
+import initDatadog from "./modules/datadog";
 
 try {
+    // Initialise datadog monitoring
+    initDatadog();
+    
     initErrorSummary();
     window.parent.postMessage(
     {

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,9 +2,13 @@
 import initHeader from '@citizensadvice/design-system/lib/header';
 import initGreedyNav from "./modules/greedy-nav";
 import initSupplierTableButton from "./modules/supplier-table";
+import initDatadog from "./modules/datadog";
 
 try {
-  // Initialise design-system modules first
+  // Initialise datadog monitoring
+  initDatadog();
+
+  // Initialise design-system modules
   initHeader();
   initGreedyNav();
 
@@ -14,3 +18,5 @@ try {
   document.querySelector("html").classList.add("no-js");
   throw error;
 }
+
+throw new Error("This is a deliberate error from the energy apps javascript")

--- a/app/javascript/modules/datadog.js
+++ b/app/javascript/modules/datadog.js
@@ -6,7 +6,7 @@ const initDatadog = () => {
 
     if (ddEnv && appVersion) {
         datadogLogs.init({
-            clientToken: 'pub32a7538113d7910e4304b8aa13ff4521',
+            clientToken: 'pub32a7538113d7910e4304b8aa13ff4521', // this is a public token designed to be used in client side js
             site: 'datadoghq.eu',
             forwardErrorsToLogs: true,
             sessionSampleRate: 100,

--- a/app/javascript/modules/datadog.js
+++ b/app/javascript/modules/datadog.js
@@ -1,0 +1,20 @@
+import { datadogLogs } from '@datadog/browser-logs'
+
+const initDatadog = () => {
+    const ddEnv = window.location.hostname === 'www.citizensadvice.org.uk' ? "prod" : "dev";
+    const appVersion = document.querySelector('meta[name="app-version"]').getAttribute('content');
+
+    if (ddEnv && appVersion) {
+        datadogLogs.init({
+            clientToken: 'pub32a7538113d7910e4304b8aa13ff4521',
+            site: 'datadoghq.eu',
+            forwardErrorsToLogs: true,
+            sessionSampleRate: 100,
+            service: 'energy-apps',
+            env: ddEnv,
+            version: appVersion
+        });
+    }
+}
+
+export default initDatadog;

--- a/app/views/layouts/appliance_calculator.html.haml
+++ b/app/views/layouts/appliance_calculator.html.haml
@@ -9,6 +9,8 @@
       document.querySelector('html').classList.remove('no-js');
 
     = stylesheet_link_tag "appliance-calculator"
+    = render "shared/head_datadog"
+
 
   %body
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,6 +18,7 @@
     = render "shared/head_analytics"
 
     = stylesheet_link_tag "energy-csr-table"
+    = render "shared/head_datadog"
 
   %body{ class: ("cas" if scotland?) }
     = render "shared/google_tag_manager_no_script"

--- a/app/views/shared/_head_datadog.haml
+++ b/app/views/shared/_head_datadog.haml
@@ -1,0 +1,1 @@
+%meta{ name: "app-version", content: ENV.fetch("APP_VERSION", nil) }

--- a/infrastructure/app/chart/energy-apps/values.yaml
+++ b/infrastructure/app/chart/energy-apps/values.yaml
@@ -10,7 +10,8 @@ image:
   tag: "main"
 
 # plain env vars. Take precedence over any secrets with the same name!
-envVars: {}
+envVars:
+  APP_VERSION: ${{ github.sha }}
 
 # values to store in a secret. Only intended to be set with helm --set at e.g. deployment time!!
 secrets:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": "true",
   "dependencies": {
     "@citizensadvice/design-system": "^6.2.0",
+    "@datadog/browser-logs": "^6.1.0",
     "esbuild": "^0.24.2",
     "eslint-plugin-import": "^2.31.0",
     "sass": "^1.83.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,6 +53,18 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz#037817b574262134cabd68fc4ec1a454f168407b"
   integrity sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==
 
+"@datadog/browser-core@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@datadog/browser-core/-/browser-core-6.1.0.tgz#789e367b4a5a692d5fc462d868031ca6f371cbe0"
+  integrity sha512-GQV4zkT1k6vdlFaSqRQ9oh4nPJ8aE47mw9gpD1bGIaxdnEDNtyJXo/KI17arwJBEznhcGf7pHI+2wLWx5SfQ8w==
+
+"@datadog/browser-logs@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@datadog/browser-logs/-/browser-logs-6.1.0.tgz#40f7255f992e31f0eb9832ed584cd92159fc98b5"
+  integrity sha512-yk8eNrdhaU2BuD6ffYpjgJxGbdazA06mWqzsFvzJuQUu65E9jjv7154IRN2HCAqR4TCjJ3o8cfB11TyEuHIUpg==
+  dependencies:
+    "@datadog/browser-core" "6.1.0"
+
 "@dual-bundle/import-meta-resolve@^4.1.0":
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz#519c1549b0e147759e7825701ecffd25e5819f7b"


### PR DESCRIPTION
To upload the js and sourcemaps to datadog, we need an `APP_VERSION` that is consistent across the CI run and available to the app itself, so it can be sent along with the errors raised in the client side js.  To do this, I have:
- created an env var called `APP_VERSION` and set it to the commit sha
- exposed the commit sha in a `meta` tag in the app
- used the commit sha directly in the `--release-version` flag in the `datadog upload` command

I've also turned off deployment to prod whilst I test this by raising the deliberate error in datadog (I don't want to have console errors in prod during testing).