### PR TITLE
feat: use image tag for app version

### DIFF
--- a/.github/workflows/upload-js-to-datadog.yml
+++ b/.github/workflows/upload-js-to-datadog.yml
@@ -13,6 +13,7 @@ jobs:
     env:
       DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
       DATADOG_SITE: datadoghq.eu
+      IMAGE_TAG: ${{ github.sha }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
@@ -40,5 +41,5 @@ jobs:
         run: | 
           datadog-ci sourcemaps upload ./public/energy-apps-assets \
           --service=energy-apps \
-          --release-version=${{ github.sha }} \
+          --release-version=${{ env.IMAGE_TAG }} \
           --minified-path-prefix=/energy-apps-assets/

--- a/infrastructure/app/chart/energy-apps/templates/deployment.yaml
+++ b/infrastructure/app/chart/energy-apps/templates/deployment.yaml
@@ -51,6 +51,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: APP_VERSION
+              value: {{  .Values.image.tag }}
           {{- if .Values.envVars }}
           {{- range $name, $val := .Values.envVars }}
             - name: {{ $name }}

--- a/infrastructure/app/chart/energy-apps/values.yaml
+++ b/infrastructure/app/chart/energy-apps/values.yaml
@@ -11,7 +11,7 @@ image:
 
 # plain env vars. Take precedence over any secrets with the same name!
 envVars:
-  APP_VERSION: ${{ github.sha }}
+  APP_VERSION: {{ .Values.image.tag }}
 
 # values to store in a secret. Only intended to be set with helm --set at e.g. deployment time!!
 secrets:

--- a/infrastructure/app/chart/energy-apps/values.yaml
+++ b/infrastructure/app/chart/energy-apps/values.yaml
@@ -10,8 +10,7 @@ image:
   tag: "main"
 
 # plain env vars. Take precedence over any secrets with the same name!
-envVars:
-  APP_VERSION: {{ .Values.image.tag }}
+envVars: {}
 
 # values to store in a secret. Only intended to be set with helm --set at e.g. deployment time!!
 secrets:


### PR DESCRIPTION
Follows on from https://github.com/citizensadvice/energy-apps/pull/483

Fixes the `APP_VERSION` env var so that it is:
- set directly in the `deployment.yaml` file
- more explicitly linked to the `IMAGE_TAG` used in the docker build and push step