### PR TITLE
feat: turn on prod deployments and remove js error

### DIFF
--- a/.github/workflows/deploy-energy-apps.yaml
+++ b/.github/workflows/deploy-energy-apps.yaml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: true
       max-parallel: 1
       matrix:
-        stage: ["dev"]
+        stage: ["dev", "prod"]
     environment:
       name: ${{ matrix.stage }}
     steps:

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -18,5 +18,3 @@ try {
   document.querySelector("html").classList.add("no-js");
   throw error;
 }
-
-throw new Error("This is a deliberate error from the energy apps javascript")


### PR DESCRIPTION
Re-enables prod deployments and removes the deliberate JS error now that the datadog JS error logging is working.