### PR TITLE
Feat/no js

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ gem "factory_bot_rails"
 gem "faraday"
 gem "faraday-net_http_persistent"
 gem "graphql-client"
+gem "preserve"
 gem "rails_semantic_logger"
 gem "rich_text_renderer"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,6 +324,8 @@ GEM
       racc
     pp (0.6.2)
       prettyprint
+    preserve (2.1.0)
+      actionpack (>= 3.2)
     prettyprint (0.2.0)
     propshaft (1.1.0)
       actionpack (>= 7.0.0)
@@ -543,6 +545,7 @@ DEPENDENCIES
   jsbundling-rails
   license_finder
   meta-tags (~> 2.22)
+  preserve
   propshaft
   pry-remote
   puma (~> 6.6)

--- a/app/assets/stylesheets/appliance-calculator/_reset.scss
+++ b/app/assets/stylesheets/appliance-calculator/_reset.scss
@@ -14,4 +14,6 @@ body {
   flex: 1 0 auto;
 }
 
-
+.no-js body {
+  padding-left: 0;
+}

--- a/app/components/breadcrumbs_component.rb
+++ b/app/components/breadcrumbs_component.rb
@@ -4,6 +4,10 @@
 class BreadcrumbsComponent < ViewComponent::Base
   delegate :scotland?, to: :helpers
 
+  def initialize(current_page_title:)
+    @current_page_title = current_page_title
+  end
+
   def call
     render CitizensAdviceComponents::Breadcrumbs.new(type: :no_collapse, links:)
   end
@@ -31,7 +35,7 @@ class BreadcrumbsComponent < ViewComponent::Base
     [
       { url: "https://www.citizensadvice.org.uk/consumer/", title: "Consumer" },
       { url: "https://www.citizensadvice.org.uk/consumer/energy/energy-supply/", title: "Your energy supply" },
-      { title: "Compare energy suppliers' customer service" }
+      { title: @current_page_title }
     ]
   end
 
@@ -39,7 +43,7 @@ class BreadcrumbsComponent < ViewComponent::Base
     [
       { url: "https://www.citizensadvice.org.uk/scotland/consumer/", title: "Consumer" },
       { url: "https://www.citizensadvice.org.uk/scotland/consumer/energy/energy-supply/", title: "Your energy supply" },
-      { title: "Compare energy suppliers' customer service" }
+      { title: @current_page_title }
     ]
   end
 end

--- a/app/controllers/appliance_calculator/application_controller.rb
+++ b/app/controllers/appliance_calculator/application_controller.rb
@@ -2,11 +2,21 @@
 
 module ApplianceCalculator
   class ApplicationController < ApplicationController
+    layout :choose_layout
+
     def clear
       session[:unit_rate] = nil
       session[:usages] = nil
 
       redirect_to appliance_calculator_daily_usage_creation_step_path("appliance")
+    end
+
+    def choose_layout
+      if params["no-js"].present?
+        "appliance_calculator_no_js"
+      else
+        "appliance_calculator"
+      end
     end
   end
 end

--- a/app/controllers/appliance_calculator/application_controller.rb
+++ b/app/controllers/appliance_calculator/application_controller.rb
@@ -5,6 +5,10 @@ module ApplianceCalculator
     layout :choose_layout
     preserve :"no-js"
 
+    def index
+      redirect_to appliance_calculator_daily_usage_creation_step_path("appliance")
+    end
+
     def clear
       session[:unit_rate] = nil
       session[:usages] = nil
@@ -13,7 +17,9 @@ module ApplianceCalculator
     end
 
     def choose_layout
-      if params["no-js"].present?
+      return "appliance_calculator" if params["no-js"].nil?
+
+      if params["no-js"] == "true"
         "appliance_calculator_no_js"
       else
         "appliance_calculator"

--- a/app/controllers/appliance_calculator/application_controller.rb
+++ b/app/controllers/appliance_calculator/application_controller.rb
@@ -3,6 +3,7 @@
 module ApplianceCalculator
   class ApplicationController < ApplicationController
     layout :choose_layout
+    preserve :"no-js"
 
     def clear
       session[:unit_rate] = nil

--- a/app/controllers/appliance_calculator/daily_usage_creation/steps_controller.rb
+++ b/app/controllers/appliance_calculator/daily_usage_creation/steps_controller.rb
@@ -6,7 +6,6 @@ module ApplianceCalculator
       include WizardSteps
       self.wizard_class = ::DailyUsageCreation::Wizard
 
-      layout "appliance_calculator"
       default_form_builder ::CitizensAdviceFormBuilder::FormBuilder
 
       after_action :set_headers

--- a/app/views/appliance_calculator/daily_usage_creation/steps/completed.html.haml
+++ b/app/views/appliance_calculator/daily_usage_creation/steps/completed.html.haml
@@ -7,7 +7,7 @@
   If you want to compare appliances using a different rate, press ‘Clear list’ to restart the calculator.
 
 .form-actions
-  %form{ action: appliance_calculator_path, method: "GET"}
+  %form{ action: appliance_calculator_root_path, method: "GET"}
     = render CitizensAdviceComponents::Button.new(type: :submit) do
       Add another appliance
 

--- a/app/views/layouts/appliance_calculator_no_js.html.haml
+++ b/app/views/layouts/appliance_calculator_no_js.html.haml
@@ -11,7 +11,7 @@
     .wrapper
       = render HeaderComponent.new
       = render CitizensAdviceComponents::Navigation.new(links: navigation_links)
-      = render BreadcrumbsComponent.new
+      = render BreadcrumbsComponent.new(current_page_title: "Compare how much electrical appliances cost to use")
 
       #cads-main-content
         .cads-page-content
@@ -23,4 +23,3 @@
   = render FooterComponent.new(current_path: request.path,
                                    feedback_survey_id: "J8PLH2H",
                                    columns: public_website_footer_nav_links)
-

--- a/app/views/layouts/appliance_calculator_no_js.html.haml
+++ b/app/views/layouts/appliance_calculator_no_js.html.haml
@@ -1,0 +1,26 @@
+!!!
+%html.no-js{ lang: I18n.locale }
+  %head
+    %meta{ content: "text/html; charset=UTF-8", "http-equiv": "Content-Type" }
+    %meta{ content: "width=device-width,initial-scale=1", name: "viewport" }
+    %meta{ name: "robots", content: "noindex,nofollow" }
+
+    = stylesheet_link_tag "appliance-calculator"
+
+  %body
+    .wrapper
+      = render HeaderComponent.new
+      = render CitizensAdviceComponents::Navigation.new(links: navigation_links)
+      = render BreadcrumbsComponent.new
+
+      #cads-main-content
+        .cads-page-content
+          .cads-grid-container
+            .cads-grid-row
+              %main.cads-grid-col-md-12
+                = yield
+
+  = render FooterComponent.new(current_path: request.path,
+                                   feedback_survey_id: "J8PLH2H",
+                                   columns: public_website_footer_nav_links)
+

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -27,7 +27,7 @@
     .wrapper
       = render HeaderComponent.new
       = render CitizensAdviceComponents::Navigation.new(links: navigation_links)
-      = render BreadcrumbsComponent.new
+      = render BreadcrumbsComponent.new(current_page_title: "Compare energy suppliers' customer service")
 
       #cads-main-content
         .cads-page-content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,7 +46,7 @@ Rails.application.routes.draw do
     get "/status", to: "status#index"
 
     namespace :appliance_calculator, path: "appliance-calculator" do
-      get "/", to: redirect("/appliance-calculator/daily_usage_creation/steps/appliance")
+      root to: "application#index"
       get "/clear", to: "application#clear", as: "clear"
 
       namespace :daily_usage_creation do

--- a/spec/components/breadcrumbs_component_spec.rb
+++ b/spec/components/breadcrumbs_component_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe BreadcrumbsComponent, type: :component do
+  subject { page }
+
+  let(:current_page_title) { "Appliance calculator page" }
+
+  before do
+    render_inline described_class.new(current_page_title: current_page_title)
+  end
+
+  it { is_expected.to have_text "Appliance calculator page" }
+end

--- a/spec/requests/appliance_calculator_spec.rb
+++ b/spec/requests/appliance_calculator_spec.rb
@@ -17,6 +17,12 @@ RSpec.describe "Appliance calculator" do
     it "renders the no-js layout" do
       expect(response).to render_template("show", with_layout: "appliance_calculator_no_js")
     end
+
+    it "preserves the no-js querystring parameter on subsequent requests" do
+      get appliance_calculator_daily_usage_creation_step_path("unit_rate")
+
+      expect(response).to render_template("show", with_layout: "appliance_calculator_no_js")
+    end
   end
 
   context "when the normal version is requested" do

--- a/spec/requests/appliance_calculator_spec.rb
+++ b/spec/requests/appliance_calculator_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Appliance calculator" do
+  around do |example|
+    VCR.use_cassette("daily_usage_creation/steps/appliance", match_requests_on: [:body]) do
+      example.run
+    end
+  end
+
+  context "when the no-js version is requested" do
+    before do
+      get appliance_calculator_daily_usage_creation_step_path("appliance"), params: { "no-js": true }
+    end
+
+    it "renders the no-js layout" do
+      expect(response).to render_template("show", with_layout: "appliance_calculator_no_js")
+    end
+  end
+
+  context "when the normal version is requested" do
+    before do
+      get appliance_calculator_daily_usage_creation_step_path("appliance")
+    end
+
+    it "renders the no-js layout" do
+      expect(response).to render_template("show", with_layout: "appliance_calculator")
+    end
+  end
+end

--- a/spec/requests/appliance_calculator_spec.rb
+++ b/spec/requests/appliance_calculator_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Appliance calculator" do
       get appliance_calculator_daily_usage_creation_step_path("appliance")
     end
 
-    it "renders the no-js layout" do
+    it "renders the normal layout" do
       expect(response).to render_template("show", with_layout: "appliance_calculator")
     end
   end


### PR DESCRIPTION
Caters for a no js version of the app (see https://github.com/citizensadvice/public-website/pull/4943) by
- adding an application layout with the header and footer
- looking for / persisting that qsp and showing the no-js layout when it is present
- refactoring the breadcrumbs to allow a page title to be passed in, so it can be used in the calculator and energy csr table