### PR TITLE
Exclude /status requests from Datadog logs

### DIFF
--- a/infrastructure/app/chart/energy-apps/templates/deployment.yaml
+++ b/infrastructure/app/chart/energy-apps/templates/deployment.yaml
@@ -29,7 +29,11 @@ spec:
               "source":"ruby",
               "sourcecategory":"sourcecode",
               "service":"energy-apps",
-              "log_processing_rules": []
+              "log_processing_rules": [{
+                "type": "exclude_at_match",
+                "name": "exclude_status_heartbeat",
+                "pattern" : "\"path\":\"/status\""
+              }]
           }]
       labels:
         {{- include "energy-apps.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
Kubernetes calls the /status endpoint every few seconds on every pod to check that the application is up and running. There is normally no need to send these logs to Datadog. Removing them will reduce our Datadog costs.

We already exclude these logs for public-website and content-api, and it's never caused a problem.