### PR TITLE
Fix/empty hours

### DIFF
--- a/app/models/daily_usage_creation/validators/time_usage_validator.rb
+++ b/app/models/daily_usage_creation/validators/time_usage_validator.rb
@@ -33,6 +33,8 @@ module DailyUsageCreation
       end
 
       def validate_max_daily_hours
+        return if record.hours.blank?
+
         if empty_minutes?
           record.errors.add(:base, "Enter 24 hours or fewer") if record.hours > 24
         elsif record.hours > 23

--- a/spec/models/daily_usage_creation/steps/time_usage_spec.rb
+++ b/spec/models/daily_usage_creation/steps/time_usage_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe DailyUsageCreation::Steps::TimeUsage do
       it { is_expected.to be false }
     end
 
+    context "when no value for hours but some values for minutes have been provided" do
+      let(:store) { { "hours" => nil, "minutes" => 10, "frequency" => "daily" } }
+
+      it { is_expected.to be true }
+    end
+
     context "when zero values for hours and minutes have been provided" do
       let(:store) { { "hours" => 0, "minutes" => 0, "frequency" => "daily" } }
 


### PR DESCRIPTION
Fixes a bug where the app would error if a user entered minutes but nothing for hours in the time usage step.