### PR TITLE
fix: preserve no-js param on redirect

### DIFF
--- a/app/controllers/appliance_calculator/application_controller.rb
+++ b/app/controllers/appliance_calculator/application_controller.rb
@@ -8,7 +8,7 @@ module ApplianceCalculator
     preserve :"no-js"
 
     def index
-      redirect_to appliance_calculator_daily_usage_creation_step_path("appliance")
+      redirect_to appliance_calculator_daily_usage_creation_step_path("appliance", { "no-js": params["no-js"] })
     end
 
     def clear


### PR DESCRIPTION
Ensures that the `no-js` parameter is preserved when requesting the no js version of the app from public website

Prior to this change, the param was getting lost in the redirect to the first step of the form.