### PR TITLE
fix: stop fetching contentful metadata tags in appliance calculator

### DIFF
--- a/app/controllers/queries/appliances.rb
+++ b/app/controllers/queries/appliances.rb
@@ -19,11 +19,6 @@ module Queries
         sys {
           id
         }
-        contentfulMetadata {
-          tags {
-            id
-          }
-        }
       }
     }
   }

--- a/spec/cassettes/appliance/fetch_all_production.yml
+++ b/spec/cassettes/appliance/fetch_all_production.yml
@@ -8,10 +8,10 @@ http_interactions:
       string: '{"query":"query Queries__Appliances($tag_filter: ContentfulMetadataTagsFilter)
         {\n  applianceCollection(where: {contentfulMetadata: {tags: $tag_filter}})
         {\n    items {\n      name\n      category\n      wattage\n      usageType\n      additionalUsage\n      variantQuestion\n      variantOptions\n      sys
-        {\n        id\n      }\n      contentfulMetadata {\n        tags {\n          id\n        }\n      }\n    }\n  }\n}","operationName":"Queries__Appliances","variables":{"top_three_ranks":[1,2,3],"tag_filter":{"id_contains_none":"test"}},"context":{}}'
+        {\n        id\n      }\n    }\n  }\n}","operationName":"Queries__Appliances","variables":{"top_three_ranks":[1,2,3],"tag_filter":{"id_contains_none":"test"}},"context":{}}'
     headers:
       User-Agent:
-      - Faraday v2.12.1
+      - Faraday v2.12.2
       Authorization:
       - Bearer <CONTENTFUL_CDA_TOKEN>
       Content-Type:
@@ -32,15 +32,15 @@ http_interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3438'
+      - '2976'
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - '4396657915918977668'
+      - '7096588687346905096'
       Cache-Control:
       - max-age=0
       X-Contentful-Graphql-Query-Cost:
-      - '200'
+      - '100'
       X-Contentful-Route:
       - "/spaces/:spaceId/environments/:environmentId"
       Strict-Transport-Security:
@@ -53,8 +53,6 @@ http_interactions:
       - us-east-1
       Contentful-Api:
       - gql
-      Contentful-Upstream:
-      - graph-api
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -70,37 +68,37 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Age:
-      - '230'
+      - '0'
       Date:
-      - Mon, 20 Jan 2025 16:54:55 GMT
+      - Tue, 04 Mar 2025 09:31:35 GMT
       X-Served-By:
-      - cache-ewr-kewr1740033-EWR, cache-lhr-egll1980047-LHR
+      - cache-ewr-kewr1740029-EWR, cache-lhr-egll1980024-LHR
       X-Cache-Hits:
       - 0, 0
       X-Timer:
-      - S1737392096.997785,VS0,VE1
+      - S1741080696.698223,VS0,VE154
       X-Cache:
-      - HIT
+      - MISS
       X-Contentful-Request-Id:
-      - 80d8aeb9-c151-426c-9a79-6ef8f138fd49
+      - 19420eaa-48bb-47a0-a48f-f183facc68e1
     body:
       encoding: UTF-8
       string: '{"data":{"applianceCollection":{"items":[{"sys":{"id":"3ejw5FRM0q7YSxw2e8Amrx"},"name":"Tumble
         Dryer (condenser)","category":"Large appliances","wattage":0,"usageType":"Cycles","additionalUsage":null,"variantQuestion":"How
         full is the tumble dryer?","variantOptions":{"tableData":[["Option","Wattage"],["Full
-        load","1000"],["Partial load","200"]]},"contentfulMetadata":{"tags":[]}},{"sys":{"id":"5h5O5LSdtDAOPklaUmApU6"},"name":"Broadband
-        router","category":"Home electronics","wattage":10,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}},{"sys":{"id":"2ESy0qxVyMcibw7rswEMP6"},"name":"Light
-        bulb - Halogen (800 lumens)","category":"Lighting","wattage":42,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}},{"sys":{"id":"2gtg0ZNtihWQimzgapyhTQ"},"name":"Light
-        bulb - CFL (800 lumens)","category":"Lighting","wattage":14,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}},{"sys":{"id":"1Xw32zsoKpEunb3GLiwMSJ"},"name":"Electric
-        car charger (wallbox)","category":"Outdoor appliances","wattage":7000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}},{"sys":{"id":"5S0B6uZX7qQ9vmfn6zgcV"},"name":"Tumble
-        Dryer (condenser), partial load","category":"Large appliances","wattage":1834,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}},{"sys":{"id":"2KgtXBVCVwzQmgs2tRoc9"},"name":"Tumble
-        Dryer (condenser), full load","category":"Large appliances","wattage":1939,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}},{"sys":{"id":"2gemGsN5WTp67AnWftEUP6"},"name":"Dishwasher
-        (Eco cycle)","category":"Large appliances","wattage":272,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}},{"sys":{"id":"BZBp33DZeG7tYSSD45h57"},"name":"Oven
-        (no fan) 200 °C preheated","category":"Large appliances","wattage":622,"usageType":"Time","additionalUsage":10,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}},{"sys":{"id":"4qWAo7qUij4lBUvwZpwgJ6"},"name":"Games
-        console","category":"Home electronics","wattage":120,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}},{"sys":{"id":"1DfQKPMErKdNSYznHxSh7g"},"name":"DVD
-        or Blu-ray player","category":"Home electronics","wattage":40,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}},{"sys":{"id":"1EKZxnrrKOcTO5wvf57ABn"},"name":"Fan
-        heater","category":"Heating","wattage":2500,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}},{"sys":{"id":"4sowKrXozAZIWNCsPxEXc5"},"name":"Immersion
-        heater","category":"Heating","wattage":3000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}},{"sys":{"id":"4qD9neqFYoTvDFDZYs0EIz"},"name":"Electric
-        blanket","category":"Heating","wattage":150,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[]}}]}}}'
-  recorded_at: Mon, 20 Jan 2025 16:54:56 GMT
+        load","1000"],["Partial load","200"]]}},{"sys":{"id":"5h5O5LSdtDAOPklaUmApU6"},"name":"Broadband
+        router","category":"Home electronics","wattage":10,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"2ESy0qxVyMcibw7rswEMP6"},"name":"Light
+        bulb - Halogen (800 lumens)","category":"Lighting","wattage":42,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"2gtg0ZNtihWQimzgapyhTQ"},"name":"Light
+        bulb - CFL (800 lumens)","category":"Lighting","wattage":14,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"1Xw32zsoKpEunb3GLiwMSJ"},"name":"Electric
+        car charger (wallbox)","category":"Outdoor appliances","wattage":7000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"5S0B6uZX7qQ9vmfn6zgcV"},"name":"Tumble
+        Dryer (condenser), partial load","category":"Large appliances","wattage":1834,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"2KgtXBVCVwzQmgs2tRoc9"},"name":"Tumble
+        Dryer (condenser), full load","category":"Large appliances","wattage":1939,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"2gemGsN5WTp67AnWftEUP6"},"name":"Dishwasher
+        (Eco cycle)","category":"Large appliances","wattage":272,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"BZBp33DZeG7tYSSD45h57"},"name":"Oven
+        (no fan) 200 °C preheated","category":"Large appliances","wattage":622,"usageType":"Time","additionalUsage":10,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"4qWAo7qUij4lBUvwZpwgJ6"},"name":"Games
+        console","category":"Home electronics","wattage":120,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"1DfQKPMErKdNSYznHxSh7g"},"name":"DVD
+        or Blu-ray player","category":"Home electronics","wattage":40,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"1EKZxnrrKOcTO5wvf57ABn"},"name":"Fan
+        heater","category":"Heating","wattage":2500,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"4sowKrXozAZIWNCsPxEXc5"},"name":"Immersion
+        heater","category":"Heating","wattage":3000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"4qD9neqFYoTvDFDZYs0EIz"},"name":"Electric
+        blanket","category":"Heating","wattage":150,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null}]}}}'
+  recorded_at: Tue, 04 Mar 2025 09:31:35 GMT
 recorded_with: VCR 6.3.1

--- a/spec/cassettes/appliance/fetch_all_test.yml
+++ b/spec/cassettes/appliance/fetch_all_test.yml
@@ -8,10 +8,10 @@ http_interactions:
       string: '{"query":"query Queries__Appliances($tag_filter: ContentfulMetadataTagsFilter)
         {\n  applianceCollection(where: {contentfulMetadata: {tags: $tag_filter}})
         {\n    items {\n      name\n      category\n      wattage\n      usageType\n      additionalUsage\n      variantQuestion\n      variantOptions\n      sys
-        {\n        id\n      }\n      contentfulMetadata {\n        tags {\n          id\n        }\n      }\n    }\n  }\n}","operationName":"Queries__Appliances","variables":{"top_three_ranks":[901,902,903],"tag_filter":{"id_contains_some":"test"}},"context":{}}'
+        {\n        id\n      }\n    }\n  }\n}","operationName":"Queries__Appliances","variables":{"top_three_ranks":[901,902,903],"tag_filter":{"id_contains_some":"test"}},"context":{}}'
     headers:
       User-Agent:
-      - Faraday v2.12.1
+      - Faraday v2.12.2
       Authorization:
       - Bearer <CONTENTFUL_CDA_TOKEN>
       Content-Type:
@@ -32,15 +32,15 @@ http_interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3456'
+      - '2858'
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - '16167252690045918173'
+      - '1061603462191523674'
       Cache-Control:
       - max-age=0
       X-Contentful-Graphql-Query-Cost:
-      - '200'
+      - '100'
       X-Contentful-Route:
       - "/spaces/:spaceId/environments/:environmentId"
       Strict-Transport-Security:
@@ -53,8 +53,6 @@ http_interactions:
       - us-east-1
       Contentful-Api:
       - gql
-      Contentful-Upstream:
-      - graph-api
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -69,37 +67,37 @@ http_interactions:
       - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
-      Date:
-      - Mon, 20 Jan 2025 16:54:55 GMT
       Age:
-      - '231'
+      - '234'
+      Date:
+      - Tue, 04 Mar 2025 09:31:35 GMT
       X-Served-By:
-      - cache-ewr-kewr1740033-EWR, cache-lhr-egll1980070-LHR
+      - cache-ewr-kewr1740051-EWR, cache-lhr-egll1980059-LHR
       X-Cache-Hits:
-      - 0, 1
+      - 0, 0
       X-Timer:
-      - S1737392096.964654,VS0,VE1
+      - S1741080696.655400,VS0,VE1
       X-Cache:
       - HIT
       X-Contentful-Request-Id:
-      - bb93acd8-975f-4b5b-95f4-ed497134e8cc
+      - b12d4691-d1a3-4044-bf89-9b3e32fd6708
     body:
       encoding: UTF-8
       string: '{"data":{"applianceCollection":{"items":[{"sys":{"id":"6EfvCwk0NdBevmtktMqDkx"},"name":"TEST
         - Tumble Dryer (condenser)","category":"Large appliances","wattage":0,"usageType":"Cycles","additionalUsage":null,"variantQuestion":"How
         full is the tumble dryer?","variantOptions":{"tableData":[["Option","Wattage"],["Full
-        load","1000"],["Partial load","200"]]},"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"2hf9PSZCdpYwQ40HsPmx8b"},"name":"TEST
-        - Fan heater","category":"Heating","wattage":2500,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":{"tableData":[]},"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"5FYWv9ZbTiYsTDfHKWtWnx"},"name":"TEST
-        - Broadband router","category":"Home electronics","wattage":10,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"1JpSHKsFdotffkNfCwQV0b"},"name":"TEST
-        - Light bulb - Halogen (800 lumens)","category":"Lighting","wattage":42,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"2v4Tp3ojzr64FJs6lRvG4t"},"name":"TEST
-        - Light bulb - CFL (800 lumens)","category":"Lighting","wattage":14,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"6GeHDjVGZJf1jCCC06uxXl"},"name":"TEST
-        - Electric car charger (wallbox)","category":"Outdoor appliances","wattage":7000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"6u1DKA3dCSPveybK48IbR5"},"name":"TEST
-        - Games console","category":"Home electronics","wattage":120,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"FwkA3GxDaFzkduc5Io4UV"},"name":"TEST
-        - Dishwasher (Eco cycle)","category":"Large appliances","wattage":272,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"7YoSVhgmsE9jtjhLFtVkg"},"name":"TEST
-        - Oven (no fan) 200 °C preheated","category":"Large appliances","wattage":622,"usageType":"Time","additionalUsage":10,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"7mmSMkn7tbxU9l5IXLr6GF"},"name":"TEST
-        - Tumble Dryer (condenser), full load","category":"Large appliances","wattage":1939,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"1j4RSSWNQV9j7Eyuyibn6F"},"name":"TEST
-        - DVD or Blu-ray player","category":"Home electronics","wattage":40,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"4BQ4Lt7nPkCy7eGZftdOf8"},"name":"TEST
-        - Immersion heater","category":"Heating","wattage":3000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"4Wx5RQDMmNaKARNZ0bFYUQ"},"name":"TEST
-        - Electric blanket","category":"Heating","wattage":150,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}}]}}}'
-  recorded_at: Mon, 20 Jan 2025 16:54:55 GMT
+        load","1000"],["Partial load","200"]]}},{"sys":{"id":"2hf9PSZCdpYwQ40HsPmx8b"},"name":"TEST
+        - Fan heater","category":"Heating","wattage":2500,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":{"tableData":[]}},{"sys":{"id":"5FYWv9ZbTiYsTDfHKWtWnx"},"name":"TEST
+        - Broadband router","category":"Home electronics","wattage":10,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"1JpSHKsFdotffkNfCwQV0b"},"name":"TEST
+        - Light bulb - Halogen (800 lumens)","category":"Lighting","wattage":42,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"2v4Tp3ojzr64FJs6lRvG4t"},"name":"TEST
+        - Light bulb - CFL (800 lumens)","category":"Lighting","wattage":14,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"6GeHDjVGZJf1jCCC06uxXl"},"name":"TEST
+        - Electric car charger (wallbox)","category":"Outdoor appliances","wattage":7000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"6u1DKA3dCSPveybK48IbR5"},"name":"TEST
+        - Games console","category":"Home electronics","wattage":120,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"FwkA3GxDaFzkduc5Io4UV"},"name":"TEST
+        - Dishwasher (Eco cycle)","category":"Large appliances","wattage":272,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"7YoSVhgmsE9jtjhLFtVkg"},"name":"TEST
+        - Oven (no fan) 200 °C preheated","category":"Large appliances","wattage":622,"usageType":"Time","additionalUsage":10,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"7mmSMkn7tbxU9l5IXLr6GF"},"name":"TEST
+        - Tumble Dryer (condenser), full load","category":"Large appliances","wattage":1939,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"1j4RSSWNQV9j7Eyuyibn6F"},"name":"TEST
+        - DVD or Blu-ray player","category":"Home electronics","wattage":40,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"4BQ4Lt7nPkCy7eGZftdOf8"},"name":"TEST
+        - Immersion heater","category":"Heating","wattage":3000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"4Wx5RQDMmNaKARNZ0bFYUQ"},"name":"TEST
+        - Electric blanket","category":"Heating","wattage":150,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null}]}}}'
+  recorded_at: Tue, 04 Mar 2025 09:31:35 GMT
 recorded_with: VCR 6.3.1

--- a/spec/cassettes/daily_usage_creation/steps/appliance.yml
+++ b/spec/cassettes/daily_usage_creation/steps/appliance.yml
@@ -8,10 +8,10 @@ http_interactions:
       string: '{"query":"query Queries__Appliances($tag_filter: ContentfulMetadataTagsFilter)
         {\n  applianceCollection(where: {contentfulMetadata: {tags: $tag_filter}})
         {\n    items {\n      name\n      category\n      wattage\n      usageType\n      additionalUsage\n      variantQuestion\n      variantOptions\n      sys
-        {\n        id\n      }\n      contentfulMetadata {\n        tags {\n          id\n        }\n      }\n    }\n  }\n}","operationName":"Queries__Appliances","variables":{"top_three_ranks":[901,902,903],"tag_filter":{"id_contains_some":"test"}},"context":{}}'
+        {\n        id\n      }\n    }\n  }\n}","operationName":"Queries__Appliances","variables":{"top_three_ranks":[901,902,903],"tag_filter":{"id_contains_some":"test"}},"context":{}}'
     headers:
       User-Agent:
-      - Faraday v2.12.1
+      - Faraday v2.12.2
       Authorization:
       - Bearer <CONTENTFUL_CDA_TOKEN>
       Content-Type:
@@ -32,15 +32,15 @@ http_interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3456'
+      - '2858'
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - '16167252690045918173'
+      - '1061603462191523674'
       Cache-Control:
       - max-age=0
       X-Contentful-Graphql-Query-Cost:
-      - '200'
+      - '100'
       X-Contentful-Route:
       - "/spaces/:spaceId/environments/:environmentId"
       Strict-Transport-Security:
@@ -53,8 +53,6 @@ http_interactions:
       - us-east-1
       Contentful-Api:
       - gql
-      Contentful-Upstream:
-      - graph-api
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -69,39 +67,39 @@ http_interactions:
       - 1.1 varnish, 1.1 varnish
       Accept-Ranges:
       - bytes
-      Age:
-      - '228'
       Date:
-      - Mon, 20 Jan 2025 16:54:53 GMT
+      - Tue, 04 Mar 2025 09:31:35 GMT
+      Age:
+      - '234'
       X-Served-By:
-      - cache-ewr-kewr1740033-EWR, cache-lhr-egll1980096-LHR
+      - cache-ewr-kewr1740051-EWR, cache-lhr-egll1980024-LHR
       X-Cache-Hits:
-      - 0, 0
+      - 0, 1
       X-Timer:
-      - S1737392093.006546,VS0,VE1
+      - S1741080696.921373,VS0,VE1
       X-Cache:
       - HIT
       X-Contentful-Request-Id:
-      - 0aa823b5-d4c0-4c54-8cce-9997551fe256
+      - fb2c316a-d6c9-4a9f-afed-c077e97b0f77
     body:
       encoding: UTF-8
       string: '{"data":{"applianceCollection":{"items":[{"sys":{"id":"6EfvCwk0NdBevmtktMqDkx"},"name":"TEST
         - Tumble Dryer (condenser)","category":"Large appliances","wattage":0,"usageType":"Cycles","additionalUsage":null,"variantQuestion":"How
         full is the tumble dryer?","variantOptions":{"tableData":[["Option","Wattage"],["Full
-        load","1000"],["Partial load","200"]]},"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"2hf9PSZCdpYwQ40HsPmx8b"},"name":"TEST
-        - Fan heater","category":"Heating","wattage":2500,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":{"tableData":[]},"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"5FYWv9ZbTiYsTDfHKWtWnx"},"name":"TEST
-        - Broadband router","category":"Home electronics","wattage":10,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"1JpSHKsFdotffkNfCwQV0b"},"name":"TEST
-        - Light bulb - Halogen (800 lumens)","category":"Lighting","wattage":42,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"2v4Tp3ojzr64FJs6lRvG4t"},"name":"TEST
-        - Light bulb - CFL (800 lumens)","category":"Lighting","wattage":14,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"6GeHDjVGZJf1jCCC06uxXl"},"name":"TEST
-        - Electric car charger (wallbox)","category":"Outdoor appliances","wattage":7000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"6u1DKA3dCSPveybK48IbR5"},"name":"TEST
-        - Games console","category":"Home electronics","wattage":120,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"FwkA3GxDaFzkduc5Io4UV"},"name":"TEST
-        - Dishwasher (Eco cycle)","category":"Large appliances","wattage":272,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"7YoSVhgmsE9jtjhLFtVkg"},"name":"TEST
-        - Oven (no fan) 200 °C preheated","category":"Large appliances","wattage":622,"usageType":"Time","additionalUsage":10,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"7mmSMkn7tbxU9l5IXLr6GF"},"name":"TEST
-        - Tumble Dryer (condenser), full load","category":"Large appliances","wattage":1939,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"1j4RSSWNQV9j7Eyuyibn6F"},"name":"TEST
-        - DVD or Blu-ray player","category":"Home electronics","wattage":40,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"4BQ4Lt7nPkCy7eGZftdOf8"},"name":"TEST
-        - Immersion heater","category":"Heating","wattage":3000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"4Wx5RQDMmNaKARNZ0bFYUQ"},"name":"TEST
-        - Electric blanket","category":"Heating","wattage":150,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}}]}}}'
-  recorded_at: Mon, 20 Jan 2025 16:54:53 GMT
+        load","1000"],["Partial load","200"]]}},{"sys":{"id":"2hf9PSZCdpYwQ40HsPmx8b"},"name":"TEST
+        - Fan heater","category":"Heating","wattage":2500,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":{"tableData":[]}},{"sys":{"id":"5FYWv9ZbTiYsTDfHKWtWnx"},"name":"TEST
+        - Broadband router","category":"Home electronics","wattage":10,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"1JpSHKsFdotffkNfCwQV0b"},"name":"TEST
+        - Light bulb - Halogen (800 lumens)","category":"Lighting","wattage":42,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"2v4Tp3ojzr64FJs6lRvG4t"},"name":"TEST
+        - Light bulb - CFL (800 lumens)","category":"Lighting","wattage":14,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"6GeHDjVGZJf1jCCC06uxXl"},"name":"TEST
+        - Electric car charger (wallbox)","category":"Outdoor appliances","wattage":7000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"6u1DKA3dCSPveybK48IbR5"},"name":"TEST
+        - Games console","category":"Home electronics","wattage":120,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"FwkA3GxDaFzkduc5Io4UV"},"name":"TEST
+        - Dishwasher (Eco cycle)","category":"Large appliances","wattage":272,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"7YoSVhgmsE9jtjhLFtVkg"},"name":"TEST
+        - Oven (no fan) 200 °C preheated","category":"Large appliances","wattage":622,"usageType":"Time","additionalUsage":10,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"7mmSMkn7tbxU9l5IXLr6GF"},"name":"TEST
+        - Tumble Dryer (condenser), full load","category":"Large appliances","wattage":1939,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"1j4RSSWNQV9j7Eyuyibn6F"},"name":"TEST
+        - DVD or Blu-ray player","category":"Home electronics","wattage":40,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"4BQ4Lt7nPkCy7eGZftdOf8"},"name":"TEST
+        - Immersion heater","category":"Heating","wattage":3000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"4Wx5RQDMmNaKARNZ0bFYUQ"},"name":"TEST
+        - Electric blanket","category":"Heating","wattage":150,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null}]}}}'
+  recorded_at: Tue, 04 Mar 2025 09:31:35 GMT
 - request:
     method: post
     uri: https://graphql.contentful.com/content/v1/spaces/<CONTENTFUL_SPACE_ID>/environments/master
@@ -110,10 +108,10 @@ http_interactions:
       string: '{"query":"query Queries__Appliances($tag_filter: ContentfulMetadataTagsFilter)
         {\n  applianceCollection(where: {contentfulMetadata: {tags: $tag_filter}})
         {\n    items {\n      name\n      category\n      wattage\n      usageType\n      additionalUsage\n      variantQuestion\n      variantOptions\n      sys
-        {\n        id\n      }\n      contentfulMetadata {\n        tags {\n          id\n        }\n      }\n    }\n  }\n}","operationName":"Queries__Appliances","variables":{"top_three_ranks":[901,902,903],"tag_filter":{"id_contains_some":"test"}},"context":{}}'
+        {\n        id\n      }\n    }\n  }\n}","operationName":"Queries__Appliances","variables":{"top_three_ranks":[901,902,903],"tag_filter":{"id_contains_some":"test"}},"context":{}}'
     headers:
       User-Agent:
-      - Faraday v2.12.1
+      - Faraday v2.12.2
       Authorization:
       - Bearer <CONTENTFUL_CDA_TOKEN>
       Content-Type:
@@ -134,15 +132,15 @@ http_interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '3456'
+      - '2858'
       Content-Type:
       - application/json; charset=utf-8
       Etag:
-      - '16167252690045918173'
+      - '1061603462191523674'
       Cache-Control:
       - max-age=0
       X-Contentful-Graphql-Query-Cost:
-      - '200'
+      - '100'
       X-Contentful-Route:
       - "/spaces/:spaceId/environments/:environmentId"
       Strict-Transport-Security:
@@ -155,8 +153,6 @@ http_interactions:
       - us-east-1
       Contentful-Api:
       - gql
-      Contentful-Upstream:
-      - graph-api
       Access-Control-Allow-Origin:
       - "*"
       Access-Control-Allow-Headers:
@@ -172,36 +168,36 @@ http_interactions:
       Accept-Ranges:
       - bytes
       Date:
-      - Mon, 20 Jan 2025 16:54:53 GMT
+      - Tue, 04 Mar 2025 09:31:35 GMT
       Age:
-      - '228'
+      - '234'
       X-Served-By:
-      - cache-ewr-kewr1740033-EWR, cache-lhr-egll1980096-LHR
+      - cache-ewr-kewr1740051-EWR, cache-lhr-egll1980024-LHR
       X-Cache-Hits:
-      - 0, 1
+      - 0, 2
       X-Timer:
-      - S1737392093.017567,VS0,VE1
+      - S1741080696.937090,VS0,VE0
       X-Cache:
       - HIT
       X-Contentful-Request-Id:
-      - 0575073b-76ee-4286-beb1-1cf0d04653b0
+      - 2a5c95c3-69e1-4230-8d9e-ff4a4fc183dd
     body:
       encoding: UTF-8
       string: '{"data":{"applianceCollection":{"items":[{"sys":{"id":"6EfvCwk0NdBevmtktMqDkx"},"name":"TEST
         - Tumble Dryer (condenser)","category":"Large appliances","wattage":0,"usageType":"Cycles","additionalUsage":null,"variantQuestion":"How
         full is the tumble dryer?","variantOptions":{"tableData":[["Option","Wattage"],["Full
-        load","1000"],["Partial load","200"]]},"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"2hf9PSZCdpYwQ40HsPmx8b"},"name":"TEST
-        - Fan heater","category":"Heating","wattage":2500,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":{"tableData":[]},"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"5FYWv9ZbTiYsTDfHKWtWnx"},"name":"TEST
-        - Broadband router","category":"Home electronics","wattage":10,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"1JpSHKsFdotffkNfCwQV0b"},"name":"TEST
-        - Light bulb - Halogen (800 lumens)","category":"Lighting","wattage":42,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"2v4Tp3ojzr64FJs6lRvG4t"},"name":"TEST
-        - Light bulb - CFL (800 lumens)","category":"Lighting","wattage":14,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"6GeHDjVGZJf1jCCC06uxXl"},"name":"TEST
-        - Electric car charger (wallbox)","category":"Outdoor appliances","wattage":7000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"6u1DKA3dCSPveybK48IbR5"},"name":"TEST
-        - Games console","category":"Home electronics","wattage":120,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"FwkA3GxDaFzkduc5Io4UV"},"name":"TEST
-        - Dishwasher (Eco cycle)","category":"Large appliances","wattage":272,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"7YoSVhgmsE9jtjhLFtVkg"},"name":"TEST
-        - Oven (no fan) 200 °C preheated","category":"Large appliances","wattage":622,"usageType":"Time","additionalUsage":10,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"7mmSMkn7tbxU9l5IXLr6GF"},"name":"TEST
-        - Tumble Dryer (condenser), full load","category":"Large appliances","wattage":1939,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"1j4RSSWNQV9j7Eyuyibn6F"},"name":"TEST
-        - DVD or Blu-ray player","category":"Home electronics","wattage":40,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"4BQ4Lt7nPkCy7eGZftdOf8"},"name":"TEST
-        - Immersion heater","category":"Heating","wattage":3000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}},{"sys":{"id":"4Wx5RQDMmNaKARNZ0bFYUQ"},"name":"TEST
-        - Electric blanket","category":"Heating","wattage":150,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null,"contentfulMetadata":{"tags":[{"id":"test"}]}}]}}}'
-  recorded_at: Mon, 20 Jan 2025 16:54:53 GMT
+        load","1000"],["Partial load","200"]]}},{"sys":{"id":"2hf9PSZCdpYwQ40HsPmx8b"},"name":"TEST
+        - Fan heater","category":"Heating","wattage":2500,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":{"tableData":[]}},{"sys":{"id":"5FYWv9ZbTiYsTDfHKWtWnx"},"name":"TEST
+        - Broadband router","category":"Home electronics","wattage":10,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"1JpSHKsFdotffkNfCwQV0b"},"name":"TEST
+        - Light bulb - Halogen (800 lumens)","category":"Lighting","wattage":42,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"2v4Tp3ojzr64FJs6lRvG4t"},"name":"TEST
+        - Light bulb - CFL (800 lumens)","category":"Lighting","wattage":14,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"6GeHDjVGZJf1jCCC06uxXl"},"name":"TEST
+        - Electric car charger (wallbox)","category":"Outdoor appliances","wattage":7000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"6u1DKA3dCSPveybK48IbR5"},"name":"TEST
+        - Games console","category":"Home electronics","wattage":120,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"FwkA3GxDaFzkduc5Io4UV"},"name":"TEST
+        - Dishwasher (Eco cycle)","category":"Large appliances","wattage":272,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"7YoSVhgmsE9jtjhLFtVkg"},"name":"TEST
+        - Oven (no fan) 200 °C preheated","category":"Large appliances","wattage":622,"usageType":"Time","additionalUsage":10,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"7mmSMkn7tbxU9l5IXLr6GF"},"name":"TEST
+        - Tumble Dryer (condenser), full load","category":"Large appliances","wattage":1939,"usageType":"Cycles","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"1j4RSSWNQV9j7Eyuyibn6F"},"name":"TEST
+        - DVD or Blu-ray player","category":"Home electronics","wattage":40,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"4BQ4Lt7nPkCy7eGZftdOf8"},"name":"TEST
+        - Immersion heater","category":"Heating","wattage":3000,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null},{"sys":{"id":"4Wx5RQDMmNaKARNZ0bFYUQ"},"name":"TEST
+        - Electric blanket","category":"Heating","wattage":150,"usageType":"Time","additionalUsage":null,"variantQuestion":null,"variantOptions":null}]}}}'
+  recorded_at: Tue, 04 Mar 2025 09:31:35 GMT
 recorded_with: VCR 6.3.1

--- a/spec/models/appliance_spec.rb
+++ b/spec/models/appliance_spec.rb
@@ -16,13 +16,6 @@ RSpec.describe(Appliance) do
       end
 
       it { is_expected.to be_present }
-
-      it "only return appliances that have been tagged with 'test'" do
-        all_appliances.each do |appliance|
-          tags = appliance.data.contentful_metadata.tags.map(&:id)
-          expect(tags).to include "test"
-        end
-      end
     end
 
     context "when production suppliers are fetched" do
@@ -34,12 +27,7 @@ RSpec.describe(Appliance) do
         end
       end
 
-      it "only does not return any suppliers that have been tagged with 'test'" do
-        all_appliances.each do |appliance|
-          tags = appliance.data.contentful_metadata.tags.map(&:id)
-          expect(tags).not_to include "test"
-        end
-      end
+      it { is_expected.to be_present }
     end
   end
 


### PR DESCRIPTION
We were only fetching the metadata to test it in rspecs, it is not used by the app anywhere.  This change removes the tags info from the query but still tests that appliances are returned when test and production appliances are requested.