### PR TITLE
Feat/multiple appliance time validation

### DIFF
--- a/app/models/daily_usage_creation/steps/time_usage.rb
+++ b/app/models/daily_usage_creation/steps/time_usage.rb
@@ -52,6 +52,10 @@ module DailyUsageCreation
       def next_button_text
         "Next"
       end
+
+      def quantity
+        @store[:quantity]
+      end
     end
   end
 end

--- a/spec/models/daily_usage_creation/steps/time_usage_spec.rb
+++ b/spec/models/daily_usage_creation/steps/time_usage_spec.rb
@@ -7,83 +7,103 @@ RSpec.describe DailyUsageCreation::Steps::TimeUsage do
     subject(:valid?) { described_class.new(Object.new, WizardSteps::Store.new(store), {}).valid? }
 
     context "when no values for hours and minutes have been provided" do
-      let(:store) { { "hours" => nil, "minutes" => nil, "frequency" => "daily" } }
+      let(:store) { { "quantity" => 1, "hours" => nil, "minutes" => nil, "frequency" => "daily" } }
 
       it { is_expected.to be false }
     end
 
     context "when no value for hours but some values for minutes have been provided" do
-      let(:store) { { "hours" => nil, "minutes" => 10, "frequency" => "daily" } }
+      let(:store) { { "quantity" => 1, "hours" => nil, "minutes" => 10, "frequency" => "daily" } }
 
       it { is_expected.to be true }
     end
 
     context "when zero values for hours and minutes have been provided" do
-      let(:store) { { "hours" => 0, "minutes" => 0, "frequency" => "daily" } }
+      let(:store) { { "quantity" => 1,  "hours" => 0, "minutes" => 0, "frequency" => "daily" } }
 
       it { is_expected.to be false }
     end
 
     context "when too many minutes are provided" do
-      let(:store) { { "hours" => 0, "minutes" => 100, "frequency" => "daily" } }
+      let(:store) { { "quantity" => 1, "hours" => 0, "minutes" => 100, "frequency" => "daily" } }
 
       it { is_expected.to be false }
     end
 
     context "when 59 minutes is provided" do
-      let(:store) { { "hours" => 0, "minutes" => 59, "frequency" => "daily" } }
+      let(:store) { { "quantity" => 1, "hours" => 0, "minutes" => 59, "frequency" => "daily" } }
 
       it { is_expected.to be true }
     end
 
     context "when fewer than 59 minutes is provided" do
-      let(:store) { { "hours" => 0, "minutes" => 45, "frequency" => "daily" } }
+      let(:store) { { "quantity" => 1,  "hours" => 0, "minutes" => 45, "frequency" => "daily" } }
 
       it { is_expected.to be true }
     end
 
     context "when 24 hours and no minutes are provided" do
-      let(:store) { { "hours" => 24, "minutes" => 0, "frequency" => "daily" } }
+      let(:store) { { "quantity" => 1, "hours" => 24, "minutes" => 0, "frequency" => "daily" } }
 
       it { is_expected.to be true }
     end
 
     context "when less than 24 hours and some minutes are provided" do
-      let(:store) { { "hours" => 23, "minutes" => 45, "frequency" => "daily" } }
+      let(:store) { { "quantity" => 1, "hours" => 23, "minutes" => 45, "frequency" => "daily" } }
 
       it { is_expected.to be true }
     end
 
     context "when 24 hours and some minutes are provided" do
-      let(:store) { { "hours" => 24, "minutes" => 45, "frequency" => "daily" } }
+      let(:store) { { "quantity" => 1, "hours" => 24, "minutes" => 45, "frequency" => "daily" } }
 
       it { is_expected.to be false }
     end
 
     context "when the frequency is weekly" do
       context "when 24 * 7 hours and no minutes are provided" do
-        let(:store) { { "hours" => 168, "minutes" => 0, "frequency" => "weekly" } }
+        let(:store) { { "quantity" => 1, "hours" => 168, "minutes" => 0, "frequency" => "weekly" } }
 
         it { is_expected.to be true }
       end
 
       context "when less than 24 * 7 hours and some minutes are provided" do
-        let(:store) { { "hours" => 167, "minutes" => 45, "frequency" => "weekly" } }
+        let(:store) { { "quantity" => 1, "hours" => 167, "minutes" => 45, "frequency" => "weekly" } }
 
         it { is_expected.to be true }
       end
 
       context "when 24 * 7 hours and some minutes are provided" do
-        let(:store) { { "hours" => 168, "minutes" => 30, "frequency" => "weekly" } }
+        let(:store) { { "quantity" => 1,  "hours" => 168, "minutes" => 30, "frequency" => "weekly" } }
 
         it { is_expected.to be false }
       end
     end
 
     context "when no frequency is provided" do
-      let(:store) { { "hours" => 1, "minutes" => 0, "frequency" => nil } }
+      let(:store) { { "quantity" => 1, "hours" => 1, "minutes" => 0, "frequency" => nil } }
 
       it { is_expected.to be false }
+    end
+
+    context "when more than one appliance is provided" do
+      context "when 24 * 7 hours per appliance and no minutes are provided" do
+        let(:store) { { "quantity" => 2, "hours" => 336, "minutes" => 0, "frequency" => "weekly" } }
+
+        it { is_expected.to be true }
+      end
+
+      context "when less than 24 * 7 hours per appliance and some minutes are provided" do
+        let(:store) { { "quantity" => 2, "hours" => 335, "minutes" => 45, "frequency" => "weekly" } }
+
+        it { is_expected.to be true }
+      end
+
+      context "when 24 * 7 hours per appliance and some minutes are provided" do
+        let(:store) { { "quantity" => 2, "hours" => 337, "minutes" => 30, "frequency" => "weekly" } }
+
+        it { is_expected.to be false }
+      end
     end
   end
 


### PR DESCRIPTION
Given that we are now asking users to add up their total usage across multiple appliances, the total number of hours they can enter is dynamic and based on the number of appliances they enter in step 1.

This PR updates the validation logic to allow for this.