### PR TITLE
fix: height rounding causes scroll issue when the app is in a iframe

### DIFF
--- a/app/javascript/appliance-calculator.js
+++ b/app/javascript/appliance-calculator.js
@@ -2,20 +2,14 @@ import initErrorSummary from '@citizensadvice/design-system/lib/error-summary';
 import initDismissNotice from "./modules/last_added_appliance";
 import initDatadog from "./modules/datadog";
 import initAnalytics from "./modules/appliance-calculator-analytics"
+import resizeIframe from "./modules/resize-iframe";
 
 try {
     // Initialise datadog monitoring
     initDatadog();
-
+    resizeIframe();
     initErrorSummary();
     initAnalytics();
-    window.parent.postMessage(
-    {
-      id: "#appliance_calculator",
-      height: document.body.scrollHeight,
-    },
-    "*"
-  );
     initDismissNotice()
 } catch (error) {
   document.querySelector("html").classList.add("no-js");

--- a/app/javascript/modules/resize-iframe.js
+++ b/app/javascript/modules/resize-iframe.js
@@ -1,0 +1,11 @@
+const resizeIframe = () => {
+    window.parent.postMessage(
+        {
+            id: "#appliance_calculator",
+            height: document.body.scrollHeight + 5,
+        },
+        "*"
+    );
+}
+
+export default resizeIframe;


### PR DESCRIPTION
In certain circumstances, the height of the iframe is 1 pixel short (?pixel rounding).  This causes conflicting scrolling issues when the app is iframed into an advice collection page on the main site.  This change adds a safety margin of 5px to the height sent to the parent window in `postMessage`, as well as refactoring the resizing javascript into a module so it is consistent with everything else.