### PR TITLE
fix: allow all CA subdomains only

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -43,13 +43,7 @@ module EnergyComparisonTable
     # add rspec test generator
     config.generators.test_framework = :rspec
 
-    # Review apps have dynamic subdomains
-    config.hosts << /.*\.qa\.citizensadvice\.org\.uk/
-
-    # production host
-    config.hosts << "energy-comparison-table.prod.content.citizensadvice.org.uk"
-    # new production host
-    config.hosts << "energy-apps.prod.content.citizensadvice.org.uk"
+    config.hosts << /.*\.citizensadvice\.org\.uk/
 
     # allow health check from private IP addresses
     config.hosts << /10\.\d+\.\d+\.\d+/


### PR DESCRIPTION
We want to use the `X-Forwarded-Host` header for these app now, since the appliance calculator has form POSTs, cookies and redirects.

[The change in public-website-config](https://github.com/citizensadvice/public-website-config/pull/1370) has been deployed to `okapi` ([see the example here](https://cdn.okapi.content.citizensadvice.org.uk/consumer/energy/energy-supply/interactive-tool-test/)), but we currently get a `403` error because `cdn.okapi.content.citizensadvice.org` doesn't match the allowed hosts in `config.hosts`.

