### PR TITLE
feat: make cookie name specific

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Rails.application.config.session_store :cookie_store
+Rails.application.config.session_store :cookie_store, key: "_energy_apps_session"


### PR DESCRIPTION
Makes the cookie name for the energy apps more specific so we can tell what it is out in the wild.