### PR TITLE
Fix/missing appliance bug

### DIFF
--- a/spec/requests/appliance_calculator/appliance_step_spec.rb
+++ b/spec/requests/appliance_calculator/appliance_step_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Appliance calculator" do
+RSpec.describe "Appliance step" do
   around do |example|
     VCR.use_cassette("daily_usage_creation/steps/appliance", match_requests_on: [:body]) do
       example.run
@@ -19,7 +19,7 @@ RSpec.describe "Appliance calculator" do
     end
 
     it "preserves the no-js querystring parameter on subsequent requests" do
-      get appliance_calculator_daily_usage_creation_step_path("unit_rate")
+      get appliance_calculator_daily_usage_creation_step_path("appliance")
 
       expect(response).to render_template("show", with_layout: "appliance_calculator_no_js")
     end

--- a/spec/requests/appliance_calculator/cyclical_usage_step_spec.rb
+++ b/spec/requests/appliance_calculator/cyclical_usage_step_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Cyclical usage step" do
+  context "when the step is requested directly" do
+    before do
+      get appliance_calculator_daily_usage_creation_step_path("cyclical_usage")
+    end
+
+    it "returns the user to the start step" do
+      expect(response).to redirect_to(appliance_calculator_daily_usage_creation_step_path("appliance"))
+    end
+  end
+end

--- a/spec/requests/appliance_calculator/time_based_usage_step_spec.rb
+++ b/spec/requests/appliance_calculator/time_based_usage_step_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Time usage step" do
+  context "when the step is requested directly" do
+    before do
+      get appliance_calculator_daily_usage_creation_step_path("time_usage")
+    end
+
+    it "returns the user to the start step" do
+      expect(response).to redirect_to(appliance_calculator_daily_usage_creation_step_path("appliance"))
+    end
+  end
+end

--- a/spec/requests/appliance_calculator/unit_rate_step_spec.rb
+++ b/spec/requests/appliance_calculator/unit_rate_step_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Unit rate step" do
+  context "when the step is requested directly" do
+    before do
+      get appliance_calculator_daily_usage_creation_step_path("unit_rate")
+    end
+
+    it "returns the user to the start step" do
+      expect(response).to redirect_to(appliance_calculator_daily_usage_creation_step_path("appliance"))
+    end
+  end
+end


### PR DESCRIPTION
Fixes a bug in prod where the middle steps are being accessed directly via a GET request (possibly due to the Back button).  This ensures that if a step is accessed before an appliance is selected, the user is redirected to the appliance selection step.
