### PR TITLE
Show 'Clear list' button on all steps

### DIFF
--- a/app/assets/stylesheets/appliance-calculator.scss
+++ b/app/assets/stylesheets/appliance-calculator.scss
@@ -6,4 +6,3 @@
 @import "appliance-calculator/components/usages_table";
 @import "appliance-calculator/components/most-expensive-appliance";
 @import "appliance-calculator/components/last_added_appliance";
-@import "appliance-calculator/form_actions";

--- a/app/assets/stylesheets/appliance-calculator/_form_actions.scss
+++ b/app/assets/stylesheets/appliance-calculator/_form_actions.scss
@@ -1,3 +1,0 @@
-.form-actions {
-  margin-top: $cads-spacing-5;
-}

--- a/app/components/appliance_calculator/clear_list_component.html.haml
+++ b/app/components/appliance_calculator/clear_list_component.html.haml
@@ -1,0 +1,4 @@
+%form{ action: appliance_calculator_clear_path, method: "GET" }
+  = render CitizensAdviceComponents::Button.new(variant: :tertiary, type: :submit, attributes: attrs) do
+    Clear list
+

--- a/app/components/appliance_calculator/clear_list_component.rb
+++ b/app/components/appliance_calculator/clear_list_component.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module ApplianceCalculator
+  class ClearListComponent < ViewComponent::Base
+    def initialize(usages)
+      @usages = usages
+    end
+
+    def render?
+      @usages.present?
+    end
+
+    def attrs
+      {
+        data:
+          {
+            "gtm-event": "click",
+            "gtm-event-name": "app_calc_clear_list",
+            "gtm-value": "clear-list-click"
+          }
+      }
+    end
+  end
+end

--- a/app/views/appliance_calculator/daily_usage_creation/steps/_form.html.haml
+++ b/app/views/appliance_calculator/daily_usage_creation/steps/_form.html.haml
@@ -15,3 +15,5 @@
       = "Previous"
       - c.with_icon_left do
         = render CitizensAdviceComponents::Icons::ArrowLeft.new
+
+= render ApplianceCalculator::ClearListComponent.new(usages)

--- a/app/views/appliance_calculator/daily_usage_creation/steps/completed.html.haml
+++ b/app/views/appliance_calculator/daily_usage_creation/steps/completed.html.haml
@@ -4,9 +4,6 @@
 = render ApplianceCalculator::UsagesTableComponent.new(usages: usages, unit_rate: saved_unit_rate)
 
 - add_another_attrs = { data: { "gtm-event": "click", "gtm-event-name": "app_calc_add_another_appliance", "gtm-value": "add-another-appliance-click"}}
-- clear_attrs = { data: { "gtm-event": "click", "gtm-event-name": "app_calc_clear_list", "gtm-value": "clear-list-click"}}
-
-
 
 .cads-prose
   %p
@@ -17,14 +14,11 @@
       You have added the maximum number of appliances.  If you want to compare more appliances, press ‘Clear list’ to restart the calculator.
 
 .form-actions
-
   - unless usage_limit_reached?
     %form{ action: appliance_calculator_root_path, method: "GET"}
       = render CitizensAdviceComponents::Button.new(type: :submit, attributes: add_another_attrs) do
         Add another appliance
 
-  %form{ action: appliance_calculator_clear_path, method: "GET" }
-    = render CitizensAdviceComponents::Button.new(variant: :secondary, type: :submit, attributes: clear_attrs) do
-      Clear list
+  = render ApplianceCalculator::ClearListComponent.new(usages)
 
 = render "appliance_calculator/daily_usage_creation/cost_estimation"

--- a/features/appliance_calculator/clear_list.feature
+++ b/features/appliance_calculator/clear_list.feature
@@ -14,6 +14,18 @@ Feature: Clear list
     Then I am asked how much I pay for electricity
     And I enter a unit rate
     And I confirm the rate
-    
+
     Then The list of appliances only has the broadband router and not the fan heater
 
+  Scenario: Clear list button visibility
+    Given I am on the choose an appliance step
+    Then I cannot see the "Clear list" button
+    When I add a time based usage for "TEST - Broadband router"
+    Then I am asked how much I pay for electricity
+    And I enter a unit rate
+    And I confirm the rate
+    Then I can see the "Clear list" button
+
+    When I return to the start of the form
+    And I add a time based usage for "TEST - Fan heater"
+    Then I can see the "Clear list" button

--- a/features/step_definitions/appliance_calculator/appliance_calculator_steps.rb
+++ b/features/step_definitions/appliance_calculator/appliance_calculator_steps.rb
@@ -133,3 +133,11 @@ end
 And("I am told I have added the maximum number of appliances") do
   expect(page).to have_text "You have added the maximum number of appliances"
 end
+
+Then("I can see the {string} button") do |button|
+  expect(page).to have_button(button)
+end
+
+Then("I cannot see the {string} button") do |button|
+  expect(page).to have_no_button(button)
+end


### PR DESCRIPTION
When the user has added an appliance, we want to show the `Clear list` button on every step, not just on the completed screen.