### PR TITLE
Fix links in Scotland footer

### DIFF
--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -57,7 +57,7 @@ module FooterHelper
       {
         title: "More from us",
         links: [
-          { title: "More help", url: "/scotland/about-us/" },
+          { title: "More from us", url: "/scotland/about-us/" },
           { title: "Complaints", url: "https://www.cas.org.uk/about-us/feedback/complaints" },
           { title: "Campaigns", url: "https://www.cas.org.uk/our-campaigns" },
           { title: "Publications", url: "https://www.cas.org.uk/what-we-do/our-publications" },
@@ -68,7 +68,10 @@ module FooterHelper
       {
         title: "About this site",
         links: [
-          { title: "Terms and conditions", url: "/scotland/about-us/information/terms-and-conditions-scotland/" }
+          { title: "Accessibility statement", url: "/scotland/about-us/information/accessibility-statement-scotland/" },
+          { title: "Terms and conditions", url: "/scotland/about-us/information/terms-and-conditions-scotland/" },
+          { title: "Privacy", url: "https://www.cas.org.uk/data-protection-and-cookies" },
+          { title: "Cookies", url: "/scotland/about-us/information/privacy-and-cookies-scotland/" }
         ]
       }
     ]

--- a/app/helpers/footer_helper.rb
+++ b/app/helpers/footer_helper.rb
@@ -58,17 +58,17 @@ module FooterHelper
         title: "More from us",
         links: [
           { title: "More help", url: "/scotland/about-us/" },
-          { title: "Complaints", url: "https://www.cas.org.uk/complaints" },
-          { title: "Campaigns", url: "https://www.cas.org.uk/campaigns" },
-          { title: "Publications", url: "https://www.cas.org.uk/publications" },
-          { title: "Support us", url: "https://www.cas.org.uk/about-us/support-our-work" },
-          { title: "Volunteering", url: "https://www.cas.org.uk/about-us/volunteer-citizens-advice-bureau" }
+          { title: "Complaints", url: "https://www.cas.org.uk/about-us/feedback/complaints" },
+          { title: "Campaigns", url: "https://www.cas.org.uk/our-campaigns" },
+          { title: "Publications", url: "https://www.cas.org.uk/what-we-do/our-publications" },
+          { title: "Support us", url: "https://www.cas.org.uk/get-involved/support-us" },
+          { title: "Volunteering", url: "https://www.cas.org.uk/get-involved/work-us/volunteer-citizens-advice-bureau" }
         ]
       },
       {
         title: "About this site",
         links: [
-          { title: "Disclaimer and copyright", url: "/scotland/resources-and-tools/about-this-site/terms-and-conditions/" }
+          { title: "Terms and conditions", url: "/scotland/about-us/information/terms-and-conditions-scotland/" }
         ]
       }
     ]


### PR DESCRIPTION
CAS have restructured cas.org.uk, and the old links were broken.

Also update some of the other Scotland footer links to be consistent with public-website.