### PR TITLE
feat: move to multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,59 @@
-FROM ruby:3.3.6-alpine3.19
+FROM ruby:3.3.6-alpine AS base
 
-RUN apk update && apk add --no-cache build-base yarn libxml2 libxslt gcompat git
+RUN apk add git --no-cache
 
-RUN gem install bundler -v '~>2.3'
+RUN gem install bundler -v 2.5.23
+
+
+
+FROM base AS dependencies
+
+RUN apk update && apk add build-base yarn nodejs
+
+
+WORKDIR /tmp
+
+COPY package.json yarn.lock /tmp/
+COPY Gemfile* /tmp/
+
+RUN yarn install --frozen-lockfile
+
+RUN bundle config set frozen true \
+    && bundle install
+
+
+# ASSETS
+# Uses the DEPENDENCIES layer to build the static assets (CS & JSS)
+FROM dependencies AS assets
+
+COPY . /app/
 
 WORKDIR /app
 
-COPY Gemfile Gemfile.lock /app/
+# build assets
+RUN bin/rails assets:precompile
 
-RUN bundle config set --local deployment 'true' && \  
-    bundle install
 
-COPY package.json yarn.lock /app/
-RUN yarn install --frozen-lockfile
 
-COPY ./ /app
+# APP
+# The final image that is deployed into environments (does not contain any build tools added by DEPENDENCIES)
+FROM base AS app
 
-RUN bundle exec rake assets:precompile RAILS_ENV=production
+COPY . /app/
 
-# Add user group
-RUN addgroup ruby
+COPY --from=dependencies /usr/local/bundle/ /usr/local/bundle/
+COPY --from=dependencies /tmp/node_modules/ /app/node_modules/
+COPY --from=assets /app/public/ /app/public/
+
 
 # Add user
-RUN adduser -h /home/ruby -D 3000 ruby 
+RUN adduser -D -u 3000 app \
+    && chown app: /app \
+    && chown --recursive app: /app/tmp /app/log
 
-# Change temp and log dir perms
-RUN rm -rf /app/tmp /app/log \
-&& mkdir /app/tmp /app/log \
-&& chmod -R 777 /app/tmp /app/log
+WORKDIR /app
 
 USER 3000
+EXPOSE 3000
 
 CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,6 @@ WORKDIR /app
 # build assets
 RUN bin/rails assets:precompile
 
-
-
 # APP
 # The final image that is deployed into environments (does not contain any build tools added by DEPENDENCIES)
 FROM base AS app
@@ -44,7 +42,7 @@ COPY . /app/
 COPY --from=dependencies /usr/local/bundle/ /usr/local/bundle/
 COPY --from=dependencies /tmp/node_modules/ /app/node_modules/
 COPY --from=assets /app/public/ /app/public/
-
+COPY --from=assets /app/js-build-meta.json /app/js-build-meta.json
 
 # Add user
 RUN adduser -D -u 3000 app \


### PR DESCRIPTION
Moves the docker build to a multi stage build, removing build tools from the final deployed image.  Same as the changes made to the smart meter tool in https://github.com/citizensadvice/smart-meter-tool/pull/528