### PR TITLE
fix: remove metadata.environment from PDB config

### DIFF
--- a/infrastructure/app/chart/energy-apps/templates/poddisruptionbudget.yaml
+++ b/infrastructure/app/chart/energy-apps/templates/poddisruptionbudget.yaml
@@ -6,7 +6,6 @@ metadata:
   name: {{ include "energy-apps.fullname" . }}
   labels:
     app: {{ include "energy-apps.fullname" . }}
-    env: {{ .Values.metadata.environment }}
     chart: {{ include "energy-apps.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -15,7 +14,6 @@ spec:
   selector:
     matchLabels:
       app: {{ include "energy-apps.fullname" . }}
-      env: {{ .Values.metadata.environment }}
       release: {{ .Release.Name }}
       component: app
   maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}


### PR DESCRIPTION
The PDB refers to a missing environment value in `.Values.metadata`.  We do not use this anywhere else so it is fine to delete it