### PR TITLE
feat: add a prestop hook to avoid race conditions

### DIFF
--- a/infrastructure/app/chart/energy-apps/templates/deployment.yaml
+++ b/infrastructure/app/chart/energy-apps/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          lifecycle:
+            preStop:
+              sleep:
+                seconds: 10
           readinessProbe:
             httpGet:
               path: /status


### PR DESCRIPTION
There is a documented race condition between kubernetes removing a pod and puma stopping (see https://github.com/puma/puma/blob/master/docs/kubernetes.md).