### PR TITLE
chore: add net-imap CVE to .trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# Added 05/06/25:
+# Review once net-imap version has been bumped, and the security issue resolved, in the ruby:3.3.8-alpine3.21 Docker image
+CVE-2025-43857


### PR DESCRIPTION
To ignore vulnerability warning for a vulnerability that doesn't affect us because we don't use net-imap.