### PR TITLE
chore: add uptime monitoring

### DIFF
--- a/infrastructure/app/chart/energy-apps/templates/probe.yaml
+++ b/infrastructure/app/chart/energy-apps/templates/probe.yaml
@@ -9,7 +9,6 @@ metadata:
     env: {{ .Values.metadata.environment }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    app.kubernetes.io/component: web
 spec:
   interval: 60s
   module: http_2xx

--- a/infrastructure/app/chart/energy-apps/templates/web_probe.yaml
+++ b/infrastructure/app/chart/energy-apps/templates/web_probe.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.ingress.probe.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: Probe
+metadata:
+  name: {{ template "energy-apps.fullname" . }}
+  labels:
+    app: {{ include "energy-apps.fullname" . }}
+    chart: {{ include "energy-apps.chart" . }}
+    env: {{ .Values.metadata.environment }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    app.kubernetes.io/component: web
+spec:
+  interval: 60s
+  module: http_2xx
+  prober:
+    path: /probe
+    url: prometheus-blackbox-exporter.kube-monitoring.svc.cluster.local:9115
+  targets:
+    staticConfig:
+      static: []
+{{- end }}

--- a/infrastructure/app/chart/energy-apps/values.yaml
+++ b/infrastructure/app/chart/energy-apps/values.yaml
@@ -55,6 +55,11 @@ service:
   port: 3000
 
 ingress:
+  probe:
+    enabled: false
+    targets:
+      staticConfig:
+        static: []
   enabled: false
   hostname: energy-apps.minikube
   annotations:

--- a/infrastructure/app/stages/dev.yaml
+++ b/infrastructure/app/stages/dev.yaml
@@ -1,6 +1,12 @@
 service:
   type: NodePort
 ingress:
+  probe:
+    enabled: true
+    targets:
+      staticConfig:
+        static:
+          - https://energy-apps.qa.citizensadvice.org.uk
   enabled: true
   redirectHttpToHttps: true
   annotations:

--- a/infrastructure/app/stages/prod.yaml
+++ b/infrastructure/app/stages/prod.yaml
@@ -1,6 +1,13 @@
 service:
   type: NodePort
 ingress:
+  probe:
+    enabled: true
+    targets:
+      staticConfig:
+        static:
+          - https://www.citizensadvice.org.uk/consumer/energy/energy-supply/save-energy-at-home/check-how-much-your-electrical-appliances-cost-to-use/
+          - https://www.citizensadvice.org.uk/consumer/your-energy/get-a-better-energy-deal/compare-domestic-energy-suppliers-customer-service/
   enabled: true
   redirectHttpToHttps: true
   annotations:


### PR DESCRIPTION
Follows [SRE documentation on adding a probe to monitor website availability](https://citizensadvice.atlassian.net/wiki/spaces/OPS/pages/4471653100/Kubernetes+add+a+Probe+to+monitor+website+availability). [Jira ticket CP-748](https://citizensadvice.atlassian.net/browse/CP-748). 

Testing the uptime monitoring with `energy-apps`, with a view to adding to other Content Platform apps.