### PR TITLE
Remove zalando schedule actions

### DIFF
--- a/infrastructure/app/stages/dev.yaml
+++ b/infrastructure/app/stages/dev.yaml
@@ -16,13 +16,6 @@ ingress:
     alb.ingress.kubernetes.io/healthcheck-path: /status
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
 
-annotations:
-  zalando.org/schedule-actions: |
-    [
-      {"schedule": "30 18 * * Mon-Fri", "replicas": "0", "tz": "Europe/London"},
-      {"schedule": "40 7 * * Mon-Fri", "replicas": "1", "tz": "Europe/London"}
-    ]
-
 envVars:
   RAILS_ENV: production
   USE_TEST_SUPPLIERS: ${{ vars.USE_TEST_SUPPLIERS }}


### PR DESCRIPTION
Scheduling was set to take the dev app down overnight and at weekends, but this isn't compatible with uptime monitoring that we've added for the dev environment.