### PR TITLE
Increase min replicas add PDB to dev

### DIFF
--- a/infrastructure/app/chart/energy-apps/values.yaml
+++ b/infrastructure/app/chart/energy-apps/values.yaml
@@ -69,9 +69,9 @@ resources:
     memory: 192Mi
 
 autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
+  enabled: true
+  minReplicas: 2
+  maxReplicas: 8
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 

--- a/infrastructure/app/stages/dev.yaml
+++ b/infrastructure/app/stages/dev.yaml
@@ -20,11 +20,3 @@ envVars:
   RAILS_ENV: production
   USE_TEST_SUPPLIERS: ${{ vars.USE_TEST_SUPPLIERS }}
   FF_SMALL_SUPPLIER_STARS: ${{ vars.FF_SMALL_SUPPLIER_STARS }}
-
-autoscaling:
-  enabled: true
-  minReplicas: 1
-  maxReplicas: 8
-
-podDisruptionBudget:
-  enabled: false

--- a/infrastructure/app/stages/prod.yaml
+++ b/infrastructure/app/stages/prod.yaml
@@ -20,8 +20,3 @@ ingress:
 envVars:
   RAILS_ENV: production
   FF_SMALL_SUPPLIER_STARS: ${{ vars.FF_SMALL_SUPPLIER_STARS }}
-
-autoscaling:
-  enabled: true
-  minReplicas: 2
-  maxReplicas: 8


### PR DESCRIPTION
Increases `minReplicas` to 2 for `dev` to match `prod`, and adds a PDB to `dev`. 

This is to stop dev being unavailable when the node is rotated due to underutilization. The pods being killed was resulting in the dev app being unavailable and alerts posting in [#content-platform_develop_kube_alerts](https://acab.slack.com/archives/C05ABFT5NTG).