### PR TITLE
Revert "[dependabot:actions] bump citizensadvice/build-and-private-ecr-push-action from 1 to 3"

### DIFF
--- a/.github/workflows/deploy-energy-apps.yaml
+++ b/.github/workflows/deploy-energy-apps.yaml
@@ -18,7 +18,7 @@ jobs:
       issues: read
     steps:
       - name: Build and push to ECR
-        uses: citizensadvice/build-and-private-ecr-push-action@v3
+        uses: citizensadvice/build-and-private-ecr-push-action@v1
         with:
           dockerfile_context: "."
           repository_name: energy-apps

--- a/.github/workflows/review-app-create.yml
+++ b/.github/workflows/review-app-create.yml
@@ -27,7 +27,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'Review app')
     steps:
       - name: Build and push to ECR
-        uses: citizensadvice/build-and-private-ecr-push-action@v3
+        uses: citizensadvice/build-and-private-ecr-push-action@v1
         with:
           dockerfile_context: "."
           repository_name: energy-apps


### PR DESCRIPTION
Reverts citizensadvice/energy-apps#558

`build` job of `deploy-energy-apps` workflow can't find Dockerfile. Can't immediately see why that should be the case, so reverting for now.

Note that `build` is currently using `citizensadvice/build-and-private-ecr-push-action`, which is described as being for private repos only. The README for `citizensadvice/build-and-push-action` also confusingly identifies itself as being for private repos, despite being linked to from `citizensadvice/build-and-private-ecr-push-action` as the option for public repos. I've [asked SRE to confirm whether we should be using citizensadvice/build-and-push-action instead](https://acab.slack.com/archives/C061NCX5SM8/p1752224685613389).