### PR TITLE
fix: add actions checkout step to build image jobs

### DIFF
--- a/.github/workflows/deploy-energy-apps.yaml
+++ b/.github/workflows/deploy-energy-apps.yaml
@@ -17,6 +17,7 @@ jobs:
       contents: read
       issues: read
     steps:
+      - uses: actions/checkout@v4
       - name: Build and push to ECR
         uses: citizensadvice/build-and-private-ecr-push-action@v3
         with:

--- a/.github/workflows/review-app-create.yml
+++ b/.github/workflows/review-app-create.yml
@@ -26,6 +26,7 @@ jobs:
     # are created and destroyed on every push for no reason.
     if: contains(github.event.pull_request.labels.*.name, 'Review app')
     steps:
+      - uses: actions/checkout@v4
       - name: Build and push to ECR
         uses: citizensadvice/build-and-private-ecr-push-action@v3
         with:


### PR DESCRIPTION
Should allow v3 of citizensadvice/build-and-private-ecr-push-action to be able to build the image successfully. Without the actions checkout step the build image job was failing to find Dockerfile