### PR TITLE
chore: upgrade to version 3

### DIFF
--- a/.github/workflows/deploy-energy-apps.yaml
+++ b/.github/workflows/deploy-energy-apps.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build and push to ECR
-        uses: citizensadvice/build-and-private-ecr-push-action@v1
+        uses: citizensadvice/build-and-private-ecr-push-action@v3
         with:
           dockerfile_context: "."
           repository_name: energy-apps

--- a/.github/workflows/review-app-create.yml
+++ b/.github/workflows/review-app-create.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build and push to ECR
-        uses: citizensadvice/build-and-private-ecr-push-action@v1
+        uses: citizensadvice/build-and-private-ecr-push-action@v3
         with:
           dockerfile_context: "."
           repository_name: energy-apps


### PR DESCRIPTION
Upgrade citizensadvice/build-and-private-ecr-push-action to version 3