### PR TITLE
feat: update default electricity unit rate

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -72,6 +72,6 @@ module EnergyComparisonTable
 
     config.session_store :disabled
 
-    config.x.default_unit_rate = 27.03
+    config.x.default_unit_rate = 25.73
   end
 end


### PR DESCRIPTION
Default unit rate for the energy appliance calculator changed to 25.73 pence per kWh with effect from around 1st July. See [trello card](https://trello.com/c/47kMVXHy/1915-appliance-calculator-july-price-cap-increase) and [jira ticket](https://citizensadvice.atlassian.net/browse/CP-866).