### PR TITLE
Mount the cookie preference engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,12 +36,14 @@ gem "bootsnap", require: false
 
 gem "citizens_advice_components",
     github: "citizensadvice/design-system",
-    tag: "v6.4.2",
+    tag: "v8.0.3",
     glob: "engine/*.gemspec"
 
 gem "citizens_advice_form_builder",
     github: "citizensadvice/rails-form-builder",
     tag: "v0.2.0"
+
+gem "citizens_advice_cookie_preferences", github: "citizensadvice/cookie-preferences"
 
 gem "view_component", "~> 3.23"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,14 +20,28 @@ GIT
       rubocop-rspec_rails (~> 2.31)
 
 GIT
+  remote: https://github.com/citizensadvice/cookie-preferences.git
+  revision: 9cabce056e5ec4db4c9746d8577b2cbe1ce91bb2
+  specs:
+    citizens_advice_cookie_preferences (0.1.0)
+      citizens_advice_components (> 8.0.0)
+      rails (>= 7.1.0)
+      view_component (>= 2.0.0, < 4.0)
+
+GIT
   remote: https://github.com/citizensadvice/design-system.git
-  revision: efe786cca5823edc4934031cec494d79c5b62082
-  tag: v6.4.2
+  revision: abea66c928ebe755372da567f5db8d339d3532ea
+  tag: v8.0.3
   glob: engine/*.gemspec
   specs:
-    citizens_advice_components (6.4.2)
-      actionpack (>= 7.0.0, < 9.0)
-      railties (>= 7.0.0, < 9.0)
+    citizens_advice_components (8.0.3)
+      actionpack (>= 7.1.0, < 9.0)
+      actionview (>= 7.1.0, < 9.0)
+      activemodel (>= 7.1.0, < 9.0)
+      activerecord (>= 7.1.0, < 9.0)
+      activesupport (>= 7.1.0, < 9.0)
+      rails-i18n (>= 7.0.10)
+      railties (>= 7.1.0, < 9.0)
       view_component (>= 2.0.0, < 4.0)
 
 GIT
@@ -381,6 +395,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     rails_semantic_logger (4.17.0)
       rack
       railties (>= 5.1)
@@ -539,6 +556,7 @@ DEPENDENCIES
   capybara_accessible_selectors!
   citizens-advice-style!
   citizens_advice_components!
+  citizens_advice_cookie_preferences!
   citizens_advice_form_builder!
   climate_control
   cssbundling-rails

--- a/app/assets/stylesheets/appliance-calculator.scss
+++ b/app/assets/stylesheets/appliance-calculator.scss
@@ -1,5 +1,6 @@
 @import 'appliance-calculator/settings/breakpoints';
 @import "@citizensadvice/design-system/scss/lib";
+@import 'citizens_advice_cookie_preferences/components/cookie-banner';
 @import "./appliance-calculator/reset";
 @import "./fonts";
 @import "appliance-calculator/components/frequency-input";

--- a/app/assets/stylesheets/energy-csr-table.scss
+++ b/app/assets/stylesheets/energy-csr-table.scss
@@ -1,4 +1,5 @@
 @import "@citizensadvice/design-system/scss/lib";
+@import 'citizens_advice_cookie_preferences/components/cookie-banner';
 @import "./reset";
 @import "./fonts";
 @import "./components";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 class ApplicationController < ActionController::Base
   include SwiftypeMeta
   include DataLayer
+  include CitizensAdviceCookiePreferences::Helpers
 
   def internal_server_error
     render template: "errors/500", status: :internal_server_error

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -24,6 +24,9 @@
     = render "shared/google_tag_manager_no_script"
     = render "shared/half_star_svg"
 
+    - unless cookies_preference_page?
+      = render CitizensAdviceCookiePreferences::CookieBanner.new
+
     .wrapper
       = render HeaderComponent.new
       = render CitizensAdviceComponents::Navigation.new(links: navigation_links)
@@ -48,3 +51,4 @@
                                    columns: public_website_footer_nav_links)
 
     = javascript_include_tag digested_js_file_name("application.js"), defer: true
+    = javascript_include_tag "citizens_advice_cookie_preferences/application"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,8 @@ Rails.application.routes.draw do
       end
     end
 
+    mount CitizensAdviceCookiePreferences::Engine, at: "/cookie-preferences"
+
     constraints ->(req) { req.format == :html } do
       # Custom error handler pages, these work because
       # config.exceptions_app = routes is set in application.rb

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "build": "esbuild app/javascript/*.* --bundle --sourcemap --entry-names=[name]-[hash].digested --outdir=app/assets/builds --metafile=js-build-meta.json --minify",
-    "build:css": "sass ./app/assets/stylesheets/energy-csr-table.scss:./app/assets/builds/energy-csr-table.css ./app/assets/stylesheets/appliance-calculator.scss:./app/assets/builds/appliance-calculator.css --no-source-map --load-path=node_modules",
+    "build:css": "sass ./app/assets/stylesheets/energy-csr-table.scss:./app/assets/builds/energy-csr-table.css ./app/assets/stylesheets/appliance-calculator.scss:./app/assets/builds/appliance-calculator.css --no-source-map --load-path=node_modules --load-path=$(bundle show citizens_advice_cookie_preferences)/app/assets/stylesheets",
     "lint": "yarn run lint:scss && yarn run lint:js",
     "lint:scss": "stylelint 'app/assets/stylesheets/**/*.scss'",
     "lint:js": "eslint 'app/javascript/**/*.js'"


### PR DESCRIPTION
Our previous attempts at this have ended up in a weird state so this adds the engine in a fresh branch without all the testing commits to keep it clean and easier to follow