### PR TITLE
chore: upgrade design system to v8.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem "bootsnap", require: false
 
 gem "citizens_advice_components",
     github: "citizensadvice/design-system",
-    tag: "v6.4.2",
+    tag: "v8.1.0",
     glob: "engine/*.gemspec"
 
 gem "citizens_advice_form_builder",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,14 +21,19 @@ GIT
 
 GIT
   remote: https://github.com/citizensadvice/design-system.git
-  revision: efe786cca5823edc4934031cec494d79c5b62082
-  tag: v6.4.2
+  revision: c3cb623bf7eeac13c5573d7594032bc10f611021
+  tag: v8.1.0
   glob: engine/*.gemspec
   specs:
-    citizens_advice_components (6.4.2)
-      actionpack (>= 7.0.0, < 9.0)
-      railties (>= 7.0.0, < 9.0)
-      view_component (>= 2.0.0, < 4.0)
+    citizens_advice_components (8.1.0)
+      actionpack (>= 7.1.0, < 9.0)
+      actionview (>= 7.1.0, < 9.0)
+      activemodel (>= 7.1.0, < 9.0)
+      activerecord (>= 7.1.0, < 9.0)
+      activesupport (>= 7.1.0, < 9.0)
+      rails-i18n (>= 7.0.10)
+      railties (>= 7.1.0, < 9.0)
+      view_component (>= 2.0.0, < 5.0)
 
 GIT
   remote: https://github.com/citizensadvice/rails-form-builder.git
@@ -381,6 +386,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     rails_semantic_logger (4.18.0)
       rack
       railties (>= 5.1)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "app",
   "private": "true",
   "dependencies": {
-    "@citizensadvice/design-system": "^6.4.2",
+    "@citizensadvice/design-system": "^8.1.0",
     "@datadog/browser-logs": "^6.17.0",
     "esbuild": "^0.25.8",
     "eslint-plugin-import": "^2.32.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,10 +28,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@citizensadvice/design-system@^6.4.2":
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/@citizensadvice/design-system/-/design-system-6.4.2.tgz#0f31a577d734ce98f0d190dc5740324d1f8d749a"
-  integrity sha512-NSZALoFSp/XwAcTCHSlOUqrHnxoyPDxHD8fejdVRZInx+2njcrW5VCUZL9Sc8fmUjz3FBnyy8v+O2DaoWtnKLw==
+"@citizensadvice/design-system@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@citizensadvice/design-system/-/design-system-8.1.0.tgz#32ae00c163da914f656e955cc87e6ec96cb90135"
+  integrity sha512-DUJulHNdhSbOHdso6fSg6vjROcKuXf7OC0QSm/kZnC1dMA+cOkFszi6YIVbYlK8zFl4ufOQb/GA+EU2hrBJXmA==
 
 "@csstools/css-parser-algorithms@^3.0.5":
   version "3.0.5"


### PR DESCRIPTION
Upgrades the `design-system` to v8.1.0 and therefore remove `rails-form-builder`