### PR TITLE
Cp 873 add feature tests in energy apps for the cookies

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -87,6 +87,7 @@ jobs:
       CONTENTFUL_CDA_TOKEN: ${{ secrets.CONTENTFUL_CDA_TOKEN }}
       CONTENTFUL_SPACE_ID: ${{ secrets.CONTENTFUL_SPACE_ID }}
       CONTENTFUL_ENVIRONMENT_ID: ${{ secrets.CONTENTFUL_ENVIRONMENT_ID }}
+      FF_NEW_COOKIE_MANAGEMENT: true
     needs: lint
     steps:
       - name: "Checkout"

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,6 +8,8 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.hosts << "127.0.0.1"
+
   # Configure 'rails notes' to inspect Cucumber files
   config.annotations.register_directories("features")
   config.annotations.register_extensions("feature") { |tag| /#\s*(#{tag}):?\s*(.*)$/ }

--- a/features/cookie_preferences.feature
+++ b/features/cookie_preferences.feature
@@ -1,3 +1,4 @@
+@javascript
 Feature: Cookie preferences
 
   Scenario: Visiting a page for the first time

--- a/features/cookie_preferences.feature
+++ b/features/cookie_preferences.feature
@@ -1,0 +1,5 @@
+Feature: Cookie preferences
+
+  Scenario: Visiting a page for the first time
+    Given I am on the Energy Comparison Table page
+    Then the cookie banner is rendered

--- a/features/step_definitions/cookie_preferences_steps.rb
+++ b/features/step_definitions/cookie_preferences_steps.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Then("the cookie banner is rendered") do
+  expect(page).to have_text("We'd also like to use additional cookies")
+  expect(page).to have_no_text("It looks like you have JavaScript turned off.")
+  expect(page).to have_link("find out more about the cookies we use", href: "/about-us/information/how-we-use-cookies/")
+  expect(page).to have_link("Manage cookies", href: "/cookie-preferences")
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,6 +7,7 @@
 # files.
 
 require "cucumber/rails"
+require "capybara/cucumber"
 
 # frozen_string_literal: true
 
@@ -59,3 +60,7 @@ ActionController::Base.allow_rescue = false
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 # Cucumber::Rails::Database.javascript_strategy = :truncation
+
+Capybara.configure do |config|
+  config.javascript_driver = :selenium_chrome_headless
+end


### PR DESCRIPTION
Adding a feature test to check that the cookie banner is rendered when the user first visits a page.

We had to add additional Capybara configuration - the default browser the app uses for running the feature tests is `rack_test` which doesn't run javascript. We've added `@javascript` tag only to the cookie preferences tag and adjusted it to use `selenium_chrome_headless`.