### PR TITLE
CP-932 update default electricity unit rate

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -77,6 +77,6 @@ module EnergyComparisonTable
 
     config.session_store :disabled
 
-    config.x.default_unit_rate = 25.73
+    config.x.default_unit_rate = 26.35
   end
 end


### PR DESCRIPTION
Rate changed to 26.35p with effect from 1st October 2025. See Jira ticket [CP-932](https://citizensadvice.atlassian.net/browse/CP-932).

[CP-932]: https://citizensadvice.atlassian.net/browse/CP-932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ